### PR TITLE
Fix declaration of get_reffc and get_reffi

### DIFF
--- a/components/cam/src/physics/crm/MICRO_M2005/microphysics.F90
+++ b/components/cam/src/physics/crm/MICRO_M2005/microphysics.F90
@@ -1594,12 +1594,12 @@ real(8) function total_water()
 
 end function total_water
 
-real(crm_rknd) function Get_reffc() ! liquid water
+function Get_reffc() ! liquid water
   real(crm_rknd), dimension(nx,ny,nzm) :: Get_reffc
   Get_reffc = reffc
 end function Get_reffc
 
-real(crm_rknd) function Get_reffi() ! ice
+function Get_reffi() ! ice
   real(crm_rknd), dimension(nx,ny,nzm) :: Get_reffi
   Get_reffi = reffi
 end function Get_reffi


### PR DESCRIPTION
Fix declaration of get_reffc and get_reffi functions in m2005
microphysics. The return type of these functions was declared twice,
once in the function declaration line and once in the function body,
causing the compiler to complain and die (Intel compiler on Skybridge).
Removing the type declaration from the function declaration line,
leaving just the declaration in the body (needed anyways to specify the
dimension of the return arrays) allows the 2-moment SP-CAM configuration
to build and run on skybridge. Fixes #5.