### PR TITLE
Modified SP compsets

### DIFF
--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -92,8 +92,11 @@
       <value compset="_CAM4%WCSF"     >-chem waccm_mozart_sulfur -carma sulfate</value>
       <value compset="_CAM[45]%WCMX"  >-waccmx</value>
       <!-- Super-Parameterization -->
-      <value compset="_CAM5%SP[12]V1_"     >-use_SPCAM -crm_adv MPDATA -nlev 72 -crm_nz 58 -crm_nx 64 -crm_ny 1 -crm_dx 1000 -crm_dt 10</value>
-      <value compset="_CAM5%SP[12]V1-TEST_">-use_SPCAM -crm_adv MPDATA -nlev 72 -crm_nz 58 -crm_nx  8 -crm_ny 1 -crm_dx 1000 -crm_dt 10</value>
+      <value compset="_CAM5%SP[12]V1"      >-use_SPCAM -crm_adv MPDATA -nlev 72 -crm_nz 58 -crm_dx 1000 -crm_dt 10 </value>
+      <value compset="_CAM5%SP[12]V1"      >-microphys mg2  </value>
+      <value compset="_CAM5%SP[12]V1"      >-cppdefs ' -DSP_DIR_NS -DSP_TK_LIM ' </value>
+      <value compset="_CAM5%SP[12]V1_"     >-crm_nx 32 -crm_ny 1 -crm_nx_rad 8 -crm_ny_rad 1 </value>
+      <value compset="_CAM5%SP[12]V1-TEST_">-crm_nx  8 -crm_ny 1 -crm_nx_rad 2 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP1V1"         >-SPCAM_microp_scheme sam1mom -rad rrtmg -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero</value>
       <value compset="_CAM5%SP2V1"         >-SPCAM_microp_scheme m2005   -rad rrtmg -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero</value>
       <!--  -->
@@ -326,10 +329,10 @@
     <desc compset="_CAM5%UNI"    >UNICON (modified mg1.0):</desc>
     <desc compset="CAM4.*_BGC%B"></desc>
     <!-- Super-Parameterization -->
-    <desc compset="_CAM5%SP1V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
-    <desc compset="_CAM5%SP2V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
-    <desc compset="_CAM5%SP1V1-TEST">Super-parameterized E3SM with 8x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
-    <desc compset="_CAM5%SP2V1-TEST">Super-parameterized E3SM with 8x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
+    <desc compset="_CAM5%SP1V1_"    >Super-parameterized E3SM with 32x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
+    <desc compset="_CAM5%SP2V1_"    >Super-parameterized E3SM with 32x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
+    <desc compset="_CAM5%SP1V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
+    <desc compset="_CAM5%SP2V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <!--  -->
   </description>
 

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -612,6 +612,9 @@
    <lname>20TR_CAM5%SP2V1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
+  <!-- ******************************* -->
+  <!-- ******************************* -->
+
   <entries>
 
     <entry id="RUN_STARTDATE"> 


### PR DESCRIPTION
The new SP compsets include the CRM eddy diffusivity limiter (SP_TK_LIM) by default, and also use 32 CRM columns instead of 64.