### PR TITLE
New SP compsets for SOM and fully coupled

### DIFF
--- a/cime/config/e3sm/allactive/config_compsets.xml
+++ b/cime/config/e3sm/allactive/config_compsets.xml
@@ -101,6 +101,18 @@
   <lname>2000_CAM5%AV1C-L_CLM45%SPBC_MPASCICE_MPASO_MOSART_MALI_SWAV</lname>
 </compset>
 
+<!-- super-parameterization compsets -->
+
+<compset>
+  <alias>A_WCYCL2000_SP1</alias>
+  <lname>2000_CAM5%SP1V1_CLM45%SPBC_MPASCICE_MPASO_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
+  <alias>A_WCYCL1850S_SP1</alias>
+  <lname>1850_CAM5%SP1V1_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
+</compset>
+
 <!-- E3SM v1 science compsets (hires) -->
 
 <compset>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -334,6 +334,13 @@
    <lname>20TR_CAM5%SP2V1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
+  <!-- E compset - Slab Ocean Model (SOM) -->
+
+  <compset>
+    <alias>ESP1V1</alias>
+    <lname>2000_CAM5%SP1V1_CLM45%SPBC_CICE%PRES_DOCN%SOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- ******************************* -->
   <!-- ******************************* -->
 


### PR DESCRIPTION
NOTE --- currently running another set of short runs after rebasing with the new master after merge with E3SM/master --- so this PR is a placeholder for now

Compsets added for running fully coupled and slab-ocean (SOM) simulations with SP. A short tests were run to verify that the new compsets run. 

	modified:   cime/config/e3sm/allactive/config_compsets.xml
	modified:   components/cam/cime_config/config_component.xml
	modified:   components/cam/cime_config/config_compsets.xml