### PR TITLE
Add new mac machine config

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1608,6 +1608,7 @@ lude </CFLAGS>
 </compiler>
 
 <compiler COMPILER="gnu" MACH="rhapsody">
+  <!-- Mac OSX workstation -->
   <ADD_FFLAGS>       -ffree-line-length-none  -ffixed-line-length-none </ADD_FFLAGS>
   <ADD_FFLAGS_NOOPT> -ffree-line-length-none  -ffixed-line-length-none </ADD_FFLAGS_NOOPT>
   <!-- use homebrew lapack library -->

--- a/cime/config/e3sm/machines/config_pio.xml
+++ b/cime/config/e3sm/machines/config_pio.xml
@@ -59,7 +59,6 @@
       <value mach="cades">netcdf</value>
       <value mach="grizzly">netcdf</value>
       <value mach="wolf">netcdf</value>
-      <!-- <value mach="rhapsody">netcdf</value> -->
       <value mpilib="mpi-serial">netcdf</value>
     </values>
   </entry>


### PR DESCRIPTION
Adding the new configuration for my local iMac, which should serve as a more informative template for doing local SCM simulations than the current default mac configuration template. There was an important addition to the config_compilers.xml file:
<ADD_CMAKE_OPTS MODEL="cism"> -D PIO_USE_MPIMOD:BOOL=OFF </ADD_CMAKE_OPTS>
which was a bit tricky to figure out, because without I kept getting a cryptic error message about missing include directories for ESMF during the build of PIO. For awhile I was wondering whether an installation of pnetcdf was required, but now that I have the model running I know that this is not the case. 
