### PR TITLE
Fix crm presi initialization bug; minor fixes for titan debug build

### DIFF
--- a/components/cam/src/physics/cam/crm_physics.F90
+++ b/components/cam/src/physics/cam/crm_physics.F90
@@ -1397,6 +1397,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out,spe
          crm_micro(:,:,:,:,1) = crm_qt(:,:,:,:)
          crm_micro(:,:,:,:,2) = crm_qp(:,:,:,:)
          crm_micro(:,:,:,:,3) = crm_qn(:,:,:,:)
+#ifdef m2005
       else if (SPCAM_microp_scheme .eq. 'm2005') then
          crm_micro(:,:,:,:,1)  = crm_qt(:,:,:,:)
          crm_micro(:,:,:,:,2)  = crm_nc(:,:,:,:)
@@ -1409,6 +1410,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out,spe
          crm_micro(:,:,:,:,9)  = crm_qg(:,:,:,:)
          crm_micro(:,:,:,:,10) = crm_ng(:,:,:,:)
          crm_micro(:,:,:,:,11) = crm_qc(:,:,:,:)
+#endif
       endif
 #endif
 
@@ -1590,7 +1592,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out,spe
     call crm ( lchnk,                       icol(:ncol),                  ncol,                         phys_stage,                                                 &
                state%t(:ncol,:pver),        state%q(:ncol,:pver,1),       state%q(:ncol,:pver,ixcldliq),state%q(:ncol,:pver,ixcldice),                              &
                ul(:ncol,:pver),             vl(:ncol,:pver),                                                                                                        &
-               state%ps(:ncol),             state%pmid(:ncol,:pver),      state%pdel(:ncol,:pver),      state%phis(:ncol),                                          &
+               state%ps(:ncol),             state%pmid(:ncol,:pver),      state%pint(:ncol,:pver+1),    state%pdel(:ncol,:pver),      state%phis(:ncol),            &
                state%zm(:ncol,:pver),       state%zi(:ncol,:pver+1),      ztodt,                        pver,                                                       &
 #if defined( SPMOMTRANS )
                u_tend_crm (:ncol,:pver),    v_tend_crm (:ncol,:pver),                                                                                               &

--- a/components/cam/src/physics/crm/MICRO_SAM1MOM/microphysics.F90
+++ b/components/cam/src/physics/crm/MICRO_SAM1MOM/microphysics.F90
@@ -517,16 +517,4 @@ CONTAINS
 
   end function total_water
 
-  ! -------------------------------------------------------------------------------
-  ! dummy effective radius functions:
-
-  function Get_reffc() ! liquid water
-    real(crm_rknd), pointer, dimension(:,:,:) :: Get_reffc
-  end function Get_reffc
-
-  function Get_reffi() ! ice
-    real(crm_rknd), pointer, dimension(:,:,:) :: Get_reffi
-  end function Get_reffi
-
-
 end module microphysics

--- a/components/cam/src/physics/crm/crm_module.F90
+++ b/components/cam/src/physics/crm/crm_module.F90
@@ -37,7 +37,7 @@ subroutine crm(lchnk, icol, ncrms, phys_stage, &
                 latitude0_in, longitude0_in, &
 #endif
                 tl, ql, qccl, qiil, ul, vl, &
-                ps, pmid, pdel, phis, &
+                ps, pmid, pint, pdel, phis, &
                 zmid, zint, dt_gl, plev, &
 #if defined(SPMOMTRANS)
                 ultend, vltend,          &
@@ -168,6 +168,7 @@ subroutine crm(lchnk, icol, ncrms, phys_stage, &
 #endif
     real(r8), intent(in   ) :: ps                  (ncrms)       ! Global grid surface pressure (Pa)
     real(r8), intent(in   ) :: pmid                (ncrms,plev)  ! Global grid pressure (Pa)
+    real(r8), intent(in   ) :: pint                (ncrms,plev+1)! Pressure at model interfaces
     real(r8), intent(in   ) :: pdel                (ncrms,plev)  ! Layer's pressure thickness (Pa)
     real(r8), intent(in   ) :: phis                (ncrms)       ! Global grid surface geopotential (m2/s2)
     real(r8), intent(in   ) :: zmid                (ncrms,plev)  ! Global grid height (m)
@@ -585,12 +586,14 @@ subroutine crm(lchnk, icol, ncrms, phys_stage, &
       z(k) = zmid(icrm,plev-k+1) - zint(icrm,plev+1)
       zi(k) = zint(icrm,plev-k+2)- zint(icrm,plev+1)
       pres(k) = pmid(icrm,plev-k+1)/100.
+      presi(k) = pint(icrm,plev-k+2)/100.
       prespot(k)=(1000./pres(k))**(rgas/cp)
       bet(k) = ggr/tl(icrm,plev-k+1)
       gamaz(k)=ggr/cp*z(k)
     end do ! k
    ! zi(nz) =  zint(plev-nz+2)
     zi(nz) = zint(icrm,plev-nz+2)-zint(icrm,plev+1) !+++mhwang, 2012-02-04
+    presi(nz) = pint(icrm, plev-nz+2)/100.
 
     dz = 0.5*(z(1)+z(2))
     do k=2,nzm


### PR DESCRIPTION
The crm interface pressure array (presi) was not properly initialized
because it was not used prior to the recent update to tke_full.F90.
This has now been fixed by adding "pint" as an input to the crm
subroutine and mirroring the calculation of pres.

Additional changes were required for the model to compile on titan
with debug flags:
     * add #ifdef m2005 block in crm_physics.F90
     * delete dummy Get_reff[ci] functions in
       .../src/physics/crm/MICRO_SAM1MOM/microphysics