### PR TITLE
Fix intent in species_class for chem pp_none

### DIFF
--- a/components/cam/src/chemistry/pp_none/chemistry.F90
+++ b/components/cam/src/chemistry/pp_none/chemistry.F90
@@ -130,7 +130,7 @@ contains
 
     type(physics_state), intent(in):: phys_state(begchunk:endchunk)
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
-    integer, intent(in) :: species_class(pcnst)  
+    integer, intent(inout) :: species_class(pcnst)  
 
    ! for prescribed aerosols
    ! call aero_model_init(pbuf2d)


### PR DESCRIPTION
species_class is declared as intent(in) in chem_init, but then as
intent(inout) in called routines (aero_model_init). Change intent in
chem_init to be consistent so intel will compile this.