### PR TITLE
Updates to allow superparameterized runs with -chem none

### DIFF
--- a/components/cam/src/chemistry/pp_none/chemistry.F90
+++ b/components/cam/src/chemistry/pp_none/chemistry.F90
@@ -130,7 +130,7 @@ contains
 
     type(physics_state), intent(in):: phys_state(begchunk:endchunk)
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
-    integer, intent(in) :: species_class(pcnst)  
+    integer, intent(inout) :: species_class(pcnst)  
 
    ! for prescribed aerosols
    ! call aero_model_init(pbuf2d)

--- a/components/cam/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/components/cam/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -241,10 +241,12 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
       call pbuf_get_field (pbuf, idx, t_crm)
       idx = pbuf_get_index('CRM_CLD_RAD')
       call pbuf_get_field (pbuf, idx, cldn_crm)
+#ifdef MODAL_AERO
       idx = pbuf_get_index('CRM_QAERWAT')
       call pbuf_get_field (pbuf, idx, qaerwat_crm)
       idx = pbuf_get_index('CRM_DGNUMWET')
       call pbuf_get_field (pbuf, idx, dgncur_awet_crm)
+#endif MODAL_AERO
    end if
 
 
@@ -464,10 +466,12 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
                      qaerwat(i,k,m)     = rhoh2o*naer(i,k,m)*wtrvol(i,k,m)
                   else  ! use_SPCAM
                      qaerwat(i,k,m) = qaerwat(i,k,m)+ rhoh2o*naer(i,k,m)*wtrvol(i,k,m) * (1-cldnt(i,k))
+#ifdef MODAL_AERO
                      if(k.ge.pver-crm_nz+1) then
                         qaerwat_crm(i,ii,jj,pver-k+1,m) = rhoh2o*naer(i,k,m)*wtrvol(i,k,m)
                         dgncur_awet_crm(i,ii,jj,pver-k+1,m) = dgncur_awet(i,k,m)
                      end if
+#endif
                   end if
                   !==Guangxing Lin
 


### PR DESCRIPTION
In order to run SP-E3SM with prescribed aerosols we run with no chemistry (specified with "-chem none" in CAM_CONFIG_OPTS). Minor modifications were required to make sure no CRM aerosol fields are being referenced. I have verified that this compiles and runs for SP with sam1mom microphysics.

 * Change intent(in) to intent(inout) for species_class in chemistry.F90
 * Add "#ifdef MODAL_AERO" blocks around qaerwat_crm and
   dgncur_awet_crm references in modal_aero_wateruptake