### PR TITLE
Fix ESMT bug

### DIFF
--- a/components/cam/src/physics/crm/crm_module.F90
+++ b/components/cam/src/physics/crm/crm_module.F90
@@ -1358,12 +1358,12 @@ subroutine crm(lchnk, icol, ncrms, phys_stage, dt_gl, plev, &
     uln_esmt(ptop:plev) = uln_esmt(ptop:plev) * factor_xy
     vln_esmt(ptop:plev) = vln_esmt(ptop:plev) * factor_xy
 
-    crm_output%ultend_esmt(icrm,:) = (uln_esmt(:) - crm_input%ul_esmt(icrm,:))*icrm_run_time
-    crm_output%vltend_esmt(icrm,:) = (vln_esmt(:) - crm_input%vl_esmt(icrm,:))*icrm_run_time
+    crm_output%u_tend_esmt(icrm,:) = (uln_esmt(:) - crm_input%ul_esmt(icrm,:))*icrm_run_time
+    crm_output%v_tend_esmt(icrm,:) = (vln_esmt(:) - crm_input%vl_esmt(icrm,:))*icrm_run_time
 
     ! don't use tendencies from two top levels,
-    crm_output%ultend_esmt(icrm,ptop:ptop+1) = 0.
-    crm_output%vltend_esmt(icrm,ptop:ptop+1) = 0.
+    crm_output%u_tend_esmt(icrm,ptop:ptop+1) = 0.
+    crm_output%v_tend_esmt(icrm,ptop:ptop+1) = 0.
 #endif
 
 #if defined(SPMOMTRANS)


### PR DESCRIPTION
The derived type for CRM output introduced a typoe in the name of the output variables for ESMT.

	modified:   components/cam/src/physics/crm/crm_module.F90