### PR TITLE
Add SP2V1-ECPP-TEST compset.

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -318,6 +318,7 @@
       <!-- a shorter timestep is needed for stability in SP compsets -->
       <!-- (i.e. super-parameterization, MMF, CRM) -->
       <value compset="_CAM5%SP" grid="a%ne4np4">96</value>
+      <value compset="_CAM5%SP.*ECPP" grid="a%ne4np4">144</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -105,6 +105,7 @@
       <value compset="_CAM5%SP[12]V1"      >-rad rrtmg -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
       <value compset="_CAM5%SP1V1"         >-SPCAM_microp_scheme sam1mom </value>
       <value compset="_CAM5%SP2V1"         >-SPCAM_microp_scheme m2005   </value>
+      <value compset="_CAM5%SP2V1-ECPP-TEST" >-crm_nx 8 -crm_ny 1 -use_ECPP </value>
       <!--  -->
       <value compset="GEOS_CAM"       >-offline_dyn</value>
       <value compset="GEOS_CAM4"      >-nlev 56</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -322,6 +322,11 @@
     <lname>2000_CAM5%SP2V1-TEST_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>FSP2V1-ECPP-TEST</alias>
+    <lname>2000_CAM5%SP2V1-ECPP-TEST_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- 20th century transient -->
 
   <compset>


### PR DESCRIPTION
Add compset for testing SP2 with ECPP capability. The compset
SP2V1-ECPP-TEST is identical to SP2V1-TEST except that it adds
'-use_ECPP' to CAM_CONFIG_OPTS and uses a 10-minute physics
timestep.

[BFB]