### PR TITLE
Fix radiation timestep in RRTMG

### DIFF
--- a/components/cam/src/physics/rrtmg/radiation.F90
+++ b/components/cam/src/physics/rrtmg/radiation.F90
@@ -405,20 +405,25 @@ end function radiation_nextsw_cday
     call radsw_init()
     call radlw_init()
 
-!==Guangxing Lin
-     ! Set the radiation timestep for cosz calculations if requested using the adjusted iradsw value from radiation
+    ! If we are using superparameterization, then we need to make sure that
+    ! iradsw and iradlw are both set to 1 to make sure that radiation is updated
+    ! every timestep.
+    if (use_SPCAM) then
+       iradsw = 1
+       iradlw = 1
+    end if
+
+    ! Set the radiation timestep for cosz calculations if requested using the adjusted iradsw value from radiation
     if (use_rad_dt_cosz)  then
        dtime  = get_step_size()
        dt_avg = iradsw*dtime
     end if
-
 
     call phys_getopts(history_amwg_out   = history_amwg,    &
                       history_vdiag_out  = history_vdiag,   &
                       history_budget_out = history_budget,  &
                       history_budget_histfile_num_out = history_budget_histfile_num, &
                       pergro_mods_out    = pergro_mods)
-!==Guangxing Lin
    
     ! Determine whether modal aerosols are affecting the climate, and if so
     ! then initialize the modal aerosol optics module
@@ -846,8 +851,6 @@ end function radiation_nextsw_cday
     end if
 
     ! Heating rate needed for d(theta)/dt computation
-    ! call addfld ('HR      ','K/s     ',pver, 'A','Heating rate needed for d(theta)/dt computation',phys_decomp)
-!==Guangxing Lin
     call addfld ('HR',(/ 'lev' /), 'A','K/s','Heating rate needed for d(theta)/dt computation')
 
     if ( history_budget .and. history_budget_histfile_num > 1 ) then
@@ -890,15 +893,14 @@ end function radiation_nextsw_cday
     end if
 
     if (cldfsnow_idx > 0) then
-      ! call addfld ('CLDFSNOW','1',pver,'I','CLDFSNOW',phys_decomp,flag_xyfill=.true.)
-      ! call add_default ('CLDFSNOW',1,' ')
-      ! call addfld('SNOW_ICLD_VISTAU', '1', pver, 'A', 'Snow in-cloud extinction visible sw optical depth', phys_decomp, &
-      !                                               sampling_seq='rad_lwsw', flag_xyfill=.true.)
        call addfld ('CLDFSNOW',(/ 'lev' /),'I','1','CLDFSNOW',flag_xyfill=.true.)
        call addfld('SNOW_ICLD_VISTAU', (/ 'lev' /), 'A', '1', 'Snow in-cloud extinction visible sw optical depth', &
                                                        sampling_seq='rad_lwsw', flag_xyfill=.true.)
     endif
-!==Guangxing Lin
+
+    call addfld('COSZRS', horiz_only, 'I', '1', &
+                'Cosine of solar zenith angle', &
+                sampling_seq='rad_lwsw', flag_xyfill=.true.)
 
   end subroutine radiation_init
 
@@ -1419,6 +1421,9 @@ end function radiation_nextsw_cday
        coszrs(:)=0._r8 ! coszrs is only output for zenith
     endif    
 
+    ! Output cosine solar zenith angle
+    call outfld('COSZRS', coszrs(1:ncol), ncol, lchnk)
+
     call output_rad_data(  pbuf, state, cam_in, landm, coszrs )
 
     ! Gather night/day column indices.
@@ -1434,6 +1439,8 @@ end function radiation_nextsw_cday
       end if
     end do ! i
 
+    ! Allocate "save" variables that will be used to restore fields that are
+    ! modified in-place in pbuf to populate with each crm column one at a time
     if (use_SPCAM) then
       allocate(dei_save(pcols, pver))
       allocate(dei_crm(pcols, crm_nx_rad, crm_ny_rad, crm_nz))
@@ -1445,14 +1452,16 @@ end function radiation_nextsw_cday
         allocate(lambdac_crm  (pcols, crm_nx_rad, crm_ny_Rad, crm_nz))
         allocate(des_crm      (pcols, crm_nx_rad, crm_ny_Rad, crm_nz))
       end if
-      ! calculate radiation every timestep for SP
-      dosw = .true. 
-      dolw = .true.
-    else
-      dosw     = radiation_do('sw')      ! do shortwave heating calc this timestep?
-      dolw     = radiation_do('lw')      ! do longwave heating calc this timestep?
-    endif ! use_SPCAM
+    end if
 
+    ! Figure out if we are doing radiation at this timestep. For SP-CAM, these
+    ! should ALWAYS return true...this is handled in radiation_init() by setting
+    ! iradsw = iradlw = 1
+    dosw     = radiation_do('sw')      ! do shortwave heating calc this timestep?
+    dolw     = radiation_do('lw')      ! do longwave heating calc this timestep?
+
+    ! Initialize averages over CRM columns to zero. These are aggregated over
+    ! the loop over CRM columns below.
     if (use_SPCAM) then 
       solin_m    = 0.   ; fsntoa_m   = 0. 
       fsutoa_m   = 0.   ; fsntoac_m  = 0.


### PR DESCRIPTION
Radiation needs to be done every timestep for SP runs. Previously, this
was set in `radiation_tend()` by overwriting `dosw` and `dolw`, which are set
in `radiation_do()` by checking the timestep against `iradsw` and `iradlw`.
However, the coszrs calulation is based on `iradsw`, and I believe the
land model uses `iradsw` to determine how often to update surface albedo.
So, there is a possibility of a mismatch in surface albedo and radiation
with this approach, and there is a baked-in mismatch in coszrs (because
if `iradsw > 1`, the coszrs calculation is based on a longer time period
than it should be, so radiation sees a coszrs that looks like it is
earlier in the day). This fixes these issues by setting `iradsw` and
`iradlw` in `radiation_init()` to be 1 if doing SP. The result is illustrated with the following plot, showing the cosine solar zenith angle at the first timestep using the current default in master, and with this bug fix:

![fix-rad-timestep](https://user-images.githubusercontent.com/15826727/45851376-d0c02f00-bcf7-11e8-8599-8240898002bf.png)

The solar zenith angle appears to "lag" in the current (master) case relative to the case with this fix (i.e., the sun looks like it has moved further west in the case with the fix, relative to the current behavior).

Regarding the land model updating surface albedos, note this bug report on the wiki page for the older SP-CAM [here](https://wiki.ucar.edu/pages/viewpage.action?pageId=205489281):

>GCM and radiation time step mismatch
>
>Description: In SPCAM, radiative transfer is calculated at every GCM time step (typically 600 seconds). This is achieved by setting dosw=.true. and dolw=.true. in the subroutine of radiation_tend in radiation.F90. However, the frequency of updating surface albedo is controlled through the function of radiation_do from radiation.F90. radiation_do is determined by iradsw (the frequency of shortwave radiation calculation) and iradlw (the frequency of long wave radiation calculation). The default frequency of shortwave and long wave calculation is one hour. In SPCAM5, the default values of iradsw and iradlw are not changed. Therefore surface albedo is updated every one hour, while radiation is calculated at every GCM time step. This causes some mismatch between surface albedo and radiative transfer calculation. In the worst scenario, this can cause the model to crash. This is because some nightly land grids can have surface albedo exceeding 1.0, which can then cause problems in shortwave radiation calculation. 
>
>Temporary Fix: To fix this, we need to have radiation_do to be true at every GCM time step. The suggested fix is to add the following lines to the subroutine of radiation_init in radiation.F90:
>
>   call phys_getopts( use_SPCAM_out  = use_SPCAM )
>   if(use_SPCAM) then
>     iradsw = 1
>     iradlw = 1
>   end if
>
>This will tell the model to do radiation every GCM time step. radiation_do will then always return .true., which will update surface albedo at every GCM time step. The suggested fix works for both rrtmg and camrt radiation. Please note that adding these lines in radiation_setopts does not work, as use_SPCAM has not been defined yet before the call to radiation_setopts
>
>Permanent fix will be implemented in the namelist in next release

I chose here to keep the setting of iradsw and iradlw fixed by setting them in `radiation_init()` as suggested in this bug report, rather than fixing this in the namelist for now. We probably want to eventually fix this in the namelist, and then maybe have a check in `radiation_init()` that will call `endrun` if `iradsw` or `iradlw` is not equal to 1, but this will require a bit more work to create some default namelists for SP configurations.

This PR also adds an output for COSZRS (the cosine of the solar zenith angle), and cleans up some formatting in the surrounding lines.

NOTE: this PR will NOT be BFB for SP configurations (both single moment and double moment) on master, as this bug absolutely affects the model solution.