### PR TITLE
Add a test suite for ECP integration tests

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -117,21 +117,22 @@ _TESTS = {
 
     #e3sm tests for ECP development
     "e3sm_ecp_sp" : (None, "04:00:00",
-                        ("ERP_Ld3_P96.ne4_ne4.FSP1V1-TEST",
-                         "ERS_Ld3_P96.ne4_ne4.FSP1V1-TEST",
-                         "ERP_Ld3_P96.ne4_ne4.FSP2V1-TEST",
-                         "ERP_Ld3_P96.ne4_ne4.FSP2V1-ECPP-TEST",
-                         "SMS_D_Ld1_P96.ne4_ne4.FSP1V1-TEST",
-                         "SMS_D_Ld1_P96.ne4_ne4.FSP2V1-TEST",
-                        )
+                     ("ERP_Ld3_P96.ne4_ne4.FSP1V1-TEST",
+                      "ERS_Ld3_P96.ne4_ne4.FSP1V1-TEST",
+                      "ERP_Ld3_P96.ne4_ne4.FSP2V1-TEST",
+                      "ERP_Ld3_P96.ne4_ne4.FSP2V1-ECPP-TEST",
+                      "SMS_D_Ld1_P96.ne4_ne4.FSP1V1-TEST",
+                      "SMS_D_Ld1_P96.ne4_ne4.FSP2V1-TEST",
+                     )
                     ),
-    "e3sm_ecp" :    (("e3sm_ecp_sp",), None,
+    "e3sm_ecp_nonsp" : (None, None,
                         ("ERP_Ld11.ne4_oQU240.A_WCYCL2000",
                          "ERP_Ld5.ne4_ne4.FC5AV1C-L",
                          "ERP_Ld5.ne30_ne30.FC5AV1C-L",
                          "ERS_Ld5.ne30_ne30.FC5AV1C-L",
                         )
-                    ),
+                       ),
+    "e3sm_ecp" : (("e3sm_ecp_sp", "e3sm_ecp_nonsp"), None, ()),
 
     #e3sm tests to mimic production runs
     "e3sm_prod" : (("e3sm_atm_prod",),None,


### PR DESCRIPTION
Add a test suite for ECP tests that need to run before a merge. This is
just to make generating/comparing baselines and running the tests easier.
This adds the "e3sm_ecp_sp" and "e3sm_ecp" tests suites; e3sm_ecp_sp
contains the tests with compsets that use superparameterization so that
these tests can have more walltime, and e3sm_ecp includes the
e3sm_ecp_sp suite, plus adds the non-sp tests. These *should* adopt the
default walltime limits for the individual tests, while still giving the
SP tests the walltime they need. Closes #3.