### PR TITLE
Fixes bug in SGS_TKE/diffuse_scalar

### DIFF
--- a/components/cam/src/physics/crm/SGS_TKE/diffuse_scalar.F90
+++ b/components/cam/src/physics/crm/SGS_TKE/diffuse_scalar.F90
@@ -35,7 +35,7 @@ contains
     if(RUN3D) then
       call diffuse_scalar3D (ncrms,icrm,dimx1_d,dimx2_d,dimy1_d,dimy2_d,grdf_x,grdf_y,grdf_z,f,fluxb,fluxt,tkh,rho,rhow,flux)
     else
-      call diffuse_scalar2D (ncrms,icrm,dimx1_d,dimx2_d,dimy1_d,dimy2_d,grdf_x,grdf_y,       f,fluxb,fluxt,tkh,rho,rhow,flux)
+      call diffuse_scalar2D (ncrms,icrm,dimx1_d,dimx2_d,dimy1_d,dimy2_d,grdf_x,       grdf_z,f,fluxb,fluxt,tkh,rho,rhow,flux)
     endif
 
     do k=1,nzm


### PR DESCRIPTION
diffuse_scalar2D was mistakenly passed "grdf_y" when it should
have been passed "grdf_z" in diffuse_scalars subroutine. grdf_z = 1
while grdf_y >= 16, so vertical diffusion (tkz) is at least a
factor of 16 too high.

This is an answer changing result that may have major implications ...

[non-BFB]