### PR TITLE
Update e3sm_ecp test suite with shorter SMS_D tests

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -172,8 +172,8 @@ _TESTS = {
             "ERS_Ld3_P96.ne4_ne4.FSP1V1-TEST",
             "ERP_Ld3_P96.ne4_ne4.FSP2V1-TEST",
             "ERP_Ld3_P96.ne4_ne4.FSP2V1-ECPP-TEST",
-            "SMS_D_Ld1_P96.ne4_ne4.FSP1V1-TEST",
-            "SMS_D_Ld1_P96.ne4_ne4.FSP2V1-TEST",
+            "SMS_D_Ln5_P96.ne4_ne4.FSP1V1-TEST",
+            "SMS_D_Ln5_P96.ne4_ne4.FSP2V1-TEST",
             )
         },
     "e3sm_ecp_nonsp" : {


### PR DESCRIPTION
The previous SMS_D_Ld1 SP[12]V1 tests failed to complete on
cori in the allotted 4-hour walltime. This update shortens
the test to 5 timesteps (Ln5). Fixes #95. 

[BFB]