### PR TITLE
Xyuan/summit/crm

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -206,7 +206,7 @@ for mct, etc.
 
 <compiler COMPILER="ibm">
   <CFLAGS>
-    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
+    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo -qlanglvl=90std </base>
     <append DEBUG="FALSE"> -O3  </append>
     <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp -qsuppress=1520-045 </append>
     <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt -qsuppress=1520-045 </append>
@@ -1763,6 +1763,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
 </compiler>
 
 <compiler MACH="summit" COMPILER="ibm">
@@ -1818,8 +1821,109 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <SFC> pgfortran </SFC>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <CPPDEFS>
+    <!-- http://www.pgroup.com/resources/docs.htm                                              -->
+    <!-- Notes:  (see pgi man page & user's guide for the details) -->
+    <!--  -Mextend        => Allow 132-column source lines -->
+    <!--  -Mfixed         => Assume fixed-format source -->
+    <!--  -Mfree          => Assume free-format source -->
+    <!--  -byteswapio     => Swap byte-order for unformatted i/o (big/little-endian) -->
+    <!--  -target=linux   => Specifies the target architecture to Compute Node Linux (CNL only) -->
+    <!--  -fast           => Chooses generally optimal flags for the target platform -->
+    <!--  -Mnovect        => Disables automatic vector pipelining -->
+    <!--  -Mvect=nosse    => Don't generate SSE, SSE2, 3Dnow, and prefetch instructions in loops    -->
+    <!--  -Mflushz        => Set SSE to flush-to-zero mode (underflow) loops where possible  -->
+    <!--  -Kieee          => Perform fp ops in strict conformance with the IEEE 754 standard.  -->
+    <!--                     Some optimizations disabled, slightly slower, more accurate math.  -->
+    <!--  -mp=nonuma      => Don't use thread/processors affinity (for NUMA architectures)  -->
+    <!-- -->
+    <!--  -g              => Generate symbolic debug information. Turns off optimization.   -->
+    <!--  -gopt           => Generate information for debugger without disabling optimizations  -->
+    <!--  -Mbounds        => Add array bounds checking  -->
+    <!--  -Ktrap=fp       => Determine IEEE Trap conditions fp => inv,divz,ovf   -->
+    <!--                     * inv: invalid operands         -->
+    <!--                     * divz divide by zero           -->
+    <!--                     * ovf: floating point overflow   -->
+    <!--  -F              => leaves file.f for each preprocessed file.F file  -->
+    <!--  -time           => Print execution time for each compiler step  -->
+    <append> -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI </append>
+  </CPPDEFS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
 </compiler>
+
+<compiler MACH="summit" COMPILER="pgigpu">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd -DSUMMITDEV_PGI</append>
+  </FFLAGS>
+  <FFLAGS>
+    <append DEBUG="TRUE"> -g -DSUMMITDEV_PGI</append>
+  </FFLAGS>
+  <LDFLAGS>
+    <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack -ta=nvidia,cc70,fastmath,loadcache:L1,unroll,fma,managed,ptxinfo -Mcuda</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
+  </LDFLAGS>
+  <FIXEDFLAGS>
+    <base> -Mfixed </base>
+  </FIXEDFLAGS>
+  <FREEFLAGS>
+    <base> -Mfree </base>
+  </FREEFLAGS>
+  <!-- Note that SUPPORTS_CXX is false for pgi in general, because we
+              need some machine-specific libraries -->
+  <!-- Technically, PGI does recognize this keyword during parsing,
+              but support is either buggy or incomplete, notably in that
+       the "contiguous" attribute is incompatible with "intent".-->
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+  <MPICC> mpicc </MPICC>
+  <MPICXX> mpiCC </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <SCC> pgcc </SCC>
+  <SFC> pgf95 </SFC>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <CPPDEFS>
+    <!-- http://www.pgroup.com/resources/docs.htm                                              -->
+    <!-- Notes:  (see pgi man page & user's guide for the details) -->
+    <!--  -Mextend        => Allow 132-column source lines -->
+    <!--  -Mfixed         => Assume fixed-format source -->
+    <!--  -Mfree          => Assume free-format source -->
+    <!--  -byteswapio     => Swap byte-order for unformatted i/o (big/little-endian) -->
+    <!--  -target=linux   => Specifies the target architecture to Compute Node Linux (CNL only) -->
+    <!--  -fast           => Chooses generally optimal flags for the target platform -->
+    <!--  -Mnovect        => Disables automatic vector pipelining -->
+    <!--  -Mvect=nosse    => Don't generate SSE, SSE2, 3Dnow, and prefetch instructions in loops    -->
+    <!--  -Mflushz        => Set SSE to flush-to-zero mode (underflow) loops where possible  -->
+    <!--  -Kieee          => Perform fp ops in strict conformance with the IEEE 754 standard.  -->
+    <!--                     Some optimizations disabled, slightly slower, more accurate math.  -->
+    <!--  -mp=nonuma      => Don't use thread/processors affinity (for NUMA architectures)  -->
+    <!-- -->
+    <!--  -g              => Generate symbolic debug information. Turns off optimization.   -->
+    <!--  -gopt           => Generate information for debugger without disabling optimizations  -->
+    <!--  -Mbounds        => Add array bounds checking  -->
+    <!--  -Ktrap=fp       => Determine IEEE Trap conditions fp => inv,divz,ovf   -->
+    <!--                     * inv: invalid operands         -->
+    <!--                     * divz divide by zero           -->
+    <!--                     * ovf: floating point overflow   -->
+    <!--  -F              => leaves file.f for each preprocessed file.F file  -->
+    <!--  -time           => Print execution time for each compiler step  -->
+    <append> -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI </append>
+  </CPPDEFS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
+</compiler>
+
 
 <compiler MACH="summit-cpu" COMPILER="pgi">
   <CFLAGS>
@@ -1846,34 +1950,11 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <SFC> pgfortran </SFC>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
 </compiler>
 
-<compiler MACH="summit" COMPILER="pgigpu">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -Mvect=nosimd -DSUMMITDEV_PGI </append>
-  </FFLAGS>
-  <FFLAGS>
-    <append DEBUG="TRUE"> -DSUMMITDEV_PGI </append>
-  </FFLAGS>
-  <LDFLAGS>
-    <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack -ta=nvidia,cc70,fastmath,loadcache:L1,unroll,fma,managed,ptxinfo -Mcuda</append>
-    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
-  </LDFLAGS>
-  <MPICC> mpicc </MPICC>
-  <MPICXX> mpiCC </MPICXX>
-  <MPIFC> mpif90 </MPIFC>
-  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
-  <SCC> pgcc </SCC>
-  <SFC> pgfortran </SFC>
-  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
-  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
-</compiler>
 
 <compiler MACH="syrah" COMPILER="intel">
   <CFLAGS>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2903,10 +2903,11 @@
         <command name="load">pgi/19.4</command>
       </modules>
       <modules compiler="ibm">
+        <command name="load">xalt/1.1.4</command>
         <command name="load">xl/16.1.1-3</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/6.4.0</command>
+        <command name="load">gcc/9.1.0</command>
       </modules>
 
       <modules>
@@ -3017,10 +3018,11 @@
       <command name="load">cuda</command>
     </modules>
     <modules compiler="ibm">
-      <command name="load">xl/16.1.1-1</command>
+      <command name="load">xalt/1.1.4</command>
+      <command name="load">xl/16.1.1-3</command>
     </modules>
     <modules compiler="gnu">
-      <command name="load">gcc/6.4.0</command>
+      <command name="load">gcc/9.1.0</command>
     </modules>
 
     <modules>

--- a/components/clm/src/main/clmfates_paraminterfaceMod.F90
+++ b/components/clm/src/main/clmfates_paraminterfaceMod.F90
@@ -1,7 +1,7 @@
 module CLMFatesParamInterfaceMod
   ! NOTE(bja, 2017-01) this code can not go into the main clm-fates
   ! interface module because of circular dependancies with pftvarcon.
-
+  use shr_kind_mod , only: r8 => shr_kind_r8
   use FatesGlobals, only : fates_log
   
   implicit none
@@ -171,8 +171,7 @@ contains
 
  !-----------------------------------------------------------------------
  subroutine ParametersFromNetCDF(filename, is_host_file, fates_params)
-
-   use shr_kind_mod, only: r8 => shr_kind_r8
+   !use shr_kind_mod, only: r8 =>SHR_KIND_R8
    use abortutils, only : endrun
    use fileutils  , only : getfil
    use ncdio_pio  , only : file_desc_t, ncd_pio_closefile, ncd_pio_openfile

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -374,7 +374,7 @@ MODULE WRM_subw_IO_mod
            enddo
         enddo
         if (cnt /= cntw) then
-           write(iulog,"(a,3i8)"), subname//'ERROR: sMat g2d cnt errora',cntw,cnt
+           write(iulog,"(a,3i8)") subname//'ERROR: sMat g2d cnt errora',cntw,cnt
            call shr_sys_abort(subname//' ERROR: sMat g2d cnt errora')
         endif
 
@@ -396,7 +396,7 @@ MODULE WRM_subw_IO_mod
            enddo
         enddo
         if (cnt /= cntw) then
-           write(iulog,"(a,3i8)"), subname//'ERROR: sMat d2g cnt errora',cntw,cnt
+           write(iulog,"(a,3i8)") subname//'ERROR: sMat d2g cnt errora',cntw,cnt
            call shr_sys_abort(subname//' ERROR: sMat d2g cnt errora')
         endif
 
@@ -422,7 +422,7 @@ MODULE WRM_subw_IO_mod
               enddo
            enddo
            if (cnt /= cntg) then
-              write(iulog,"(a,3i8)"), subname//'ERROR: sMat g2d cnt errorb',cntg,cnt
+              write(iulog,"(a,3i8)") subname//'ERROR: sMat g2d cnt errorb',cntg,cnt
               call shr_sys_abort(subname//' ERROR: sMat g2d cnt errorb')
            endif
         else
@@ -448,7 +448,7 @@ MODULE WRM_subw_IO_mod
               enddo
            enddo
            if (cnt /= cntg) then
-              write(iulog,"(a,3i8)"), subname//'ERROR: sMat d2g cnt errorb',cntg,cnt
+              write(iulog,"(a,3i8)") subname//'ERROR: sMat d2g cnt errorb',cntg,cnt
               call shr_sys_abort(subname//' ERROR: sMat d2g cnt errorb')
            endif
         else
@@ -810,7 +810,7 @@ MODULE WRM_subw_IO_mod
         !fname = trim(ctlSubwWRM%demandPath)// strYear//'_'//strMonth//'.nc'
         fname = trim(ctlSubwWRM%demandPath)//'1980_'//strMonth//'.nc'   ! constant 1980 demand
 
-        write(iulog,*) subname, ' reading ',trim(fname)
+        write(iulog,*) trim(subname), ' reading ',trim(fname)
 
         call ncd_pio_openfile(ncid, trim(fname), 0)
         ier = pio_inq_varid (ncid, name=ctlSubwWRM%DemandVariableName, vardesc=vardesc)  !! need to be consistent with the NC file, Tian Apr 2018
@@ -844,7 +844,7 @@ MODULE WRM_subw_IO_mod
      character(len=*),parameter :: subname = '(WRM_computeRelease)'
 
      call get_curr_date(yr, mon, day, tod)
-     write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod
+     write(iulog,'(2a,4i6)') trim(subname),'at ',yr,mon,day,tod
      do idam=1,ctlSubwWRM%localNumDam
         if ( mon .eq. WRMUnit%MthStOp(idam)) then
            WRMUnit%StorMthStOp(idam) = StorWater%storage(idam)


### PR DESCRIPTION
This PR fixes some build errors on summit machine to support the ibm xlf, pgi, pgigpu and gnu compiler, which includes
* Add/modify the compiler and configuration for summit ibm xlf, pgi, pgigpu, and gnu compiler
* Fix some grammer error in river codes.
* Move the shr_kind_mod from use in private function to top module. 

[BFB]  