### PR TITLE
Fix summit pgigpu machine files

### DIFF
--- a/cime/config/e3sm/machines/Depends.summit.cmake
+++ b/cime/config/e3sm/machines/Depends.summit.cmake
@@ -20,3 +20,95 @@ set(FILES_NEED_CUDA_FLAGS
   homme/src/share/prim_driver_base.F90
   homme/src/share/physics_mod.F90
   cam/src/control/physconst.F90)
+
+
+set(FILES_NEED_OPENACC_FLAGS
+  cam/src/physics/crm/ADV_MPDATA/advect_scalar.F90
+  cam/src/physics/crm/ADV_UM5/advect_scalar.F90
+  cam/src/physics/crm/ADV_MPDATA/advect_scalar2D.F90
+  cam/src/physics/crm/ADV_UM5/advect_scalar2D.F90
+  cam/src/physics/crm/ADV_MPDATA/advect_scalar3D.F90
+  cam/src/physics/crm/ADV_UM5/advect_scalar3D.F90
+  cam/src/physics/crm/ADV_MPDATA/advection.F90
+  cam/src/physics/crm/ADV_UM5/advection.F90
+  cam/src/physics/crm/accelerate_crm.F90
+  cam/src/physics/crm/adams.F90
+  cam/src/physics/crm/MICRO_SAM1MOM/cloud.F90
+  cam/src/physics/crm/MICRO_SAM1MOM/micro_params.F90
+  cam/src/physics/crm/MICRO_M2005/microphysics.F90
+  cam/src/physics/crm/MICRO_SAM1MOM/microphysics.F90
+  cam/src/physics/crm/MICRO_M2005FRAC/microphysics.F90
+  cam/src/physics/crm/MICRO_SAM1MOM/precip_init.F90
+  cam/src/physics/crm/MICRO_SAM1MOM/precip_proc.F90
+  cam/src/physics/crm/MICRO_SAM1MOM/precip_proc_clubb.F90
+  cam/src/physics/crm/advect2_mom_xy.F90
+  cam/src/physics/crm/SGS_TKE/diffuse_mom.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_mom.F90
+  cam/src/physics/crm/SGS_TKE/diffuse_mom2D.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_mom2D.F90
+  cam/src/physics/crm/SGS_TKE/diffuse_mom3D.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_mom3D.F90
+  cam/src/physics/crm/SGS_TKE/diffuse_scalar.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_scalar.F90
+  cam/src/physics/crm/SGS_TKE/diffuse_scalar2D.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_scalar2D.F90
+  cam/src/physics/crm/SGS_TKE/diffuse_scalar3D.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_scalar3D.F90
+  cam/src/physics/crm/SGS_TKE/sgs.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/sgs.F90
+  cam/src/physics/crm/SGS_TKE/shear_prod2D.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/shear_prod2D.F90
+  cam/src/physics/crm/SGS_TKE/shear_prod3D.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/shear_prod3D.F90
+  cam/src/physics/crm/SGS_TKE/tke_full.F90
+  cam/src/physics/crm/SGS_CLUBBkvhkvm/tke_full.F90
+  cam/src/physics/crm/abcoefs.F90
+  cam/src/physics/crm/advect2_mom_z.F90
+  cam/src/physics/crm/advect_all_scalars.F90
+  cam/src/physics/crm/buoyancy.F90
+  cam/src/physics/crm/crm_module.F90
+  cam/src/physics/crm/advect_mom.F90
+  cam/src/physics/crm/atmosphere.F90
+  cam/src/physics/crm/bound_duvdt.F90
+  cam/src/physics/crm/bound_exchange.F90
+  cam/src/physics/crm/boundaries.F90
+  cam/src/physics/crm/coriolis.F90
+  cam/src/physics/crm/crmtracers.F90
+  cam/src/physics/crm/crm_ecpp_output_module.F90
+  cam/src/physics/crm/crm_input_module.F90
+  cam/src/physics/crm/crmsurface.F90
+  cam/src/physics/crm/crm_output_module.F90
+  cam/src/physics/crm/crm_rad_module.F90
+  cam/src/physics/crm/crm_state_module.F90
+  cam/src/physics/crm/damping.F90
+  cam/src/physics/crm/grid.F90
+  cam/src/physics/crm/diagnose.F90
+  cam/src/physics/crm/params.F90
+  cam/src/physics/crm/dmdf.F90
+  cam/src/physics/crm/domain.F90
+  cam/src/physics/crm/ecppvars.F90
+  cam/src/physics/crm/fft.F90
+  cam/src/physics/crm/fftpack5.F90
+  cam/src/physics/crm/fftpack5_1d.F90
+  cam/src/physics/crm/forcing.F90
+  cam/src/physics/crm/ice_fall.F90
+  cam/src/physics/crm/kurant.F90
+  cam/src/physics/crm/press_grad.F90
+  cam/src/physics/crm/module_ecpp_stats.F90
+  cam/src/physics/crm/setparm.F90
+  cam/src/physics/crm/module_ecpp_crm_driver.F90
+  cam/src/physics/crm/press_rhs.F90
+  cam/src/physics/crm/pressure.F90
+  cam/src/physics/crm/periodic.F90
+  cam/src/physics/crm/scalar_momentum.F90
+  cam/src/physics/crm/random.F90
+  cam/src/physics/crm/setperturb.F90
+  cam/src/physics/crm/task_init.F90
+  cam/src/physics/crm/task_util_NOMPI.F90
+  cam/src/physics/crm/utils.F90
+  cam/src/physics/crm/uvw.F90
+  cam/src/physics/crm/vars.F90
+  cam/src/physics/crm/zero.F90
+  cam/src/physics/crm/openacc_utils.F90
+  cam/src/physics/crm/sat.F90 )
+

--- a/cime/config/e3sm/machines/Depends.summit.cmake
+++ b/cime/config/e3sm/machines/Depends.summit.cmake
@@ -24,44 +24,28 @@ set(FILES_NEED_CUDA_FLAGS
 
 set(FILES_NEED_OPENACC_FLAGS
   cam/src/physics/crm/ADV_MPDATA/advect_scalar.F90
-  cam/src/physics/crm/ADV_UM5/advect_scalar.F90
   cam/src/physics/crm/ADV_MPDATA/advect_scalar2D.F90
-  cam/src/physics/crm/ADV_UM5/advect_scalar2D.F90
   cam/src/physics/crm/ADV_MPDATA/advect_scalar3D.F90
-  cam/src/physics/crm/ADV_UM5/advect_scalar3D.F90
   cam/src/physics/crm/ADV_MPDATA/advection.F90
-  cam/src/physics/crm/ADV_UM5/advection.F90
   cam/src/physics/crm/accelerate_crm.F90
   cam/src/physics/crm/adams.F90
   cam/src/physics/crm/MICRO_SAM1MOM/cloud.F90
   cam/src/physics/crm/MICRO_SAM1MOM/micro_params.F90
-  cam/src/physics/crm/MICRO_M2005/microphysics.F90
   cam/src/physics/crm/MICRO_SAM1MOM/microphysics.F90
-  cam/src/physics/crm/MICRO_M2005FRAC/microphysics.F90
   cam/src/physics/crm/MICRO_SAM1MOM/precip_init.F90
   cam/src/physics/crm/MICRO_SAM1MOM/precip_proc.F90
   cam/src/physics/crm/MICRO_SAM1MOM/precip_proc_clubb.F90
   cam/src/physics/crm/advect2_mom_xy.F90
   cam/src/physics/crm/SGS_TKE/diffuse_mom.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_mom.F90
   cam/src/physics/crm/SGS_TKE/diffuse_mom2D.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_mom2D.F90
   cam/src/physics/crm/SGS_TKE/diffuse_mom3D.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_mom3D.F90
   cam/src/physics/crm/SGS_TKE/diffuse_scalar.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_scalar.F90
   cam/src/physics/crm/SGS_TKE/diffuse_scalar2D.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_scalar2D.F90
   cam/src/physics/crm/SGS_TKE/diffuse_scalar3D.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/diffuse_scalar3D.F90
   cam/src/physics/crm/SGS_TKE/sgs.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/sgs.F90
   cam/src/physics/crm/SGS_TKE/shear_prod2D.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/shear_prod2D.F90
   cam/src/physics/crm/SGS_TKE/shear_prod3D.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/shear_prod3D.F90
   cam/src/physics/crm/SGS_TKE/tke_full.F90
-  cam/src/physics/crm/SGS_CLUBBkvhkvm/tke_full.F90
   cam/src/physics/crm/abcoefs.F90
   cam/src/physics/crm/advect2_mom_z.F90
   cam/src/physics/crm/advect_all_scalars.F90

--- a/cime/config/e3sm/machines/Depends.summit.pgigpu.cmake
+++ b/cime/config/e3sm/machines/Depends.summit.pgigpu.cmake
@@ -1,0 +1,3 @@
+foreach(ITEM IN LISTS FILES_NEED_OPENACC_FLAGS)
+  set_property(SOURCE ${ITEM} APPEND_STRING PROPERTY COMPILE_FLAGS " -Minline -ta=nvidia,cc70,fastmath,loadcache:L1,unroll,fma,managed,ptxinfo -Mcuda -Minfo=accel ")
+endforeach()

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1849,6 +1849,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
 </compiler>
 
 <compiler MACH="summit" COMPILER="pgigpu">
+  <CPPDEFS>
+    <append> -DFORTRANUNDERSCORE </append>
+  </CPPDEFS>
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
   </CFLAGS>
@@ -1856,10 +1859,10 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -Mvect=nosimd -DSUMMITDEV_PGI </append>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd -DSUMMITDEV_PGI -DHAVE_IEEE_ARITHMETIC -DNO_R16 </append>
   </FFLAGS>
   <FFLAGS>
-    <append DEBUG="TRUE"> -DSUMMITDEV_PGI </append>
+    <append DEBUG="TRUE"> -DSUMMITDEV_PGI -DHAVE_IEEE_ARITHMETIC -DNO_R16 </append>
   </FFLAGS>
   <LDFLAGS>
     <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack -ta=nvidia,cc70,fastmath,loadcache:L1,unroll,fma,managed,ptxinfo -Mcuda</append>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3013,7 +3013,7 @@
       <command name="load">pgi/19.4</command>
     </modules>
     <modules compiler="pgigpu">
-      <command name="load">pgi/19.4</command>
+      <command name="load">pgi/19.7</command>
       <command name="load">cuda</command>
     </modules>
     <modules compiler="ibm">
@@ -3071,7 +3071,6 @@
     <env name="NETCDFF">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
     <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
     <env name="NETLIB_LAPACK_PATH">$ENV{OLCF_NETLIB_LAPACK_ROOT}</env>
-    <env name="PGI_ACC_POOL_ALLOC">0</env>
   </environment_variables>
   <environment_variables SMP_PRESENT="TRUE">
     <env name="OMP_NUM_THREADS">$ENV{OMP_NUM_THREADS}</env>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3071,6 +3071,7 @@
     <env name="NETCDFF">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
     <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
     <env name="NETLIB_LAPACK_PATH">$ENV{OLCF_NETLIB_LAPACK_ROOT}</env>
+    <env name="PGI_ACC_POOL_ALLOC">0</env>
   </environment_variables>
   <environment_variables SMP_PRESENT="TRUE">
     <env name="OMP_NUM_THREADS">$ENV{OMP_NUM_THREADS}</env>

--- a/components/clm/src/main/clmfates_paraminterfaceMod.F90
+++ b/components/clm/src/main/clmfates_paraminterfaceMod.F90
@@ -3,6 +3,7 @@ module CLMFatesParamInterfaceMod
   ! interface module because of circular dependancies with pftvarcon.
 
   use FatesGlobals, only : fates_log
+  use shr_kind_mod, only: r8 => shr_kind_r8
   
   implicit none
 
@@ -172,7 +173,6 @@ contains
  !-----------------------------------------------------------------------
  subroutine ParametersFromNetCDF(filename, is_host_file, fates_params)
 
-   use shr_kind_mod, only: r8 => shr_kind_r8
    use abortutils, only : endrun
    use fileutils  , only : getfil
    use ncdio_pio  , only : file_desc_t, ncd_pio_closefile, ncd_pio_openfile


### PR DESCRIPTION
- Added CMake flags for OpenACC files
- Added -DFORTRANUNDERSCORE to CPPDEFS
- Added -DHAVE_IEEE_ARITHMETIC -DNO_R16  to FFLAGS
- Switched to pgi/19.7
- Turned off the pool allocator for PGI because it currently contains a bug
- Implemented a fix for components/clm/src/main/clmfates_paraminterfaceMod.F90 that made its way into E3SM master because PGI wasn't being tested at the time