### PR TITLE
Fix Physgrid

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -754,6 +754,26 @@
       <mask>oQU240</mask>
     </model_grid>
 
+    <model_grid alias="ne4pg3_ne4pg3" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne4np4.pg3</grid>
+      <grid name="lnd">ne4np4.pg3</grid>
+      <grid name="ocnice">ne4np4.pg3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
+
+    <model_grid alias="ne4pg4_ne4pg4" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne4np4.pg4</grid>
+      <grid name="lnd">ne4np4.pg4</grid>
+      <grid name="ocnice">ne4np4.pg4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
+
     <model_grid alias="ne8_ne8" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne8np4</grid>
       <grid name="lnd">ne8np4</grid>
@@ -908,6 +928,26 @@
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
       <grid name="ocnice">ne30np4.pg2</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg3_ne30pg3" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne30np4.pg3</grid>
+      <grid name="lnd">ne30np4.pg3</grid>
+      <grid name="ocnice">ne30np4.pg3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg4_ne30pg4" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne30np4.pg4</grid>
+      <grid name="lnd">ne30np4.pg4</grid>
+      <grid name="ocnice">ne30np4.pg4</grid>
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -1827,6 +1867,20 @@
       <file grid="ice|ocn" mask="oQU240">domain.ocn.ne4pg2_oQU240.190321.nc</file>
       <desc>ne4np4.pg2 is Spectral Elem 7.5-deg grid w/ 2x2 FV physics grid per element:</desc>
     </domain>
+    <domain name="ne4np4.pg3">
+      <nx>864</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oQU240">?????</file>
+      <file grid="ice|ocn" mask="oQU240">?????</file>
+      <desc>ne4np4.pg3 is Spectral Elem 7.5-deg grid w/ 3x3 FV physics grid per element:</desc>
+    </domain>
+    <domain name="ne4np4.pg4">
+      <nx>1536</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oQU240">?????</file>
+      <file grid="ice|ocn" mask="oQU240">?????</file>
+      <desc>ne4np4.pg4 is Spectral Elem 7.5-deg grid w/ 4x4 FV physics grid per element:</desc>
+    </domain>
 
     <!--=====================================================================-->
     <!-- ne11 -->
@@ -1908,6 +1962,20 @@
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
     </domain>
+    <domain name="ne30np4.pg3">
+      <nx>48600</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg3_gx1v6.190806.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg3_gx1v6.190806.nc</file>
+      <desc>ne30np4.pg3 is Spectral Elem 1-deg grid w/ 3x3 FV physics grid per element:</desc>
+    </domain>
+    <domain name="ne30np4.pg4">
+      <nx>86400</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg4_gx1v6.190806.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg4_gx1v6.190806.nc</file>
+      <desc>ne30np4.pg4 is Spectral Elem 1-deg grid w/ 4x4 FV physics grid per element:</desc>
+    </domain>
 
     <!--=====================================================================-->
     <!-- ne60 -->
@@ -1954,6 +2022,10 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v6">DUMMY</file>
       <file grid="ice|ocn" mask="gx1v6">DUMMY</file>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_gx1v6.190819.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_gx1v6.190819.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_oECv3.190819.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_oECv3.190819.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid w/ 2x2 FV physics grid</desc>
     </domain>
 

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -41,6 +41,8 @@
 <horiz_grid dyn="se"    hgrid="ne4np4"       ncol="866"     csne="4"   csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne4np4.pg1"   ncol="96"      csne="4"   csnp="4" npg="1" />
 <horiz_grid dyn="se"    hgrid="ne4np4.pg2"   ncol="384"     csne="4"   csnp="4" npg="2" />
+<horiz_grid dyn="se"    hgrid="ne4np4.pg3"   ncol="864"     csne="4"   csnp="4" npg="3" />
+<horiz_grid dyn="se"    hgrid="ne4np4.pg4"   ncol="1536"    csne="4"   csnp="4" npg="4" />
 <horiz_grid dyn="se"    hgrid="ne5np8"       ncol="7352"    csne="5"   csnp="8" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne7np8"       ncol="14408"   csne="7"   csnp="8" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne8np4"       ncol="3458"    csne="8"   csnp="4" npg="0" />
@@ -54,6 +56,8 @@
 <horiz_grid dyn="se"    hgrid="ne30np4"      ncol="48602"   csne="30"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg1"  ncol="5400"    csne="30"  csnp="4" npg="1" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg2"  ncol="21600"   csne="30"  csnp="4" npg="2" />
+<horiz_grid dyn="se"    hgrid="ne30np4.pg3"  ncol="48600"   csne="30"  csnp="4" npg="3" />
+<horiz_grid dyn="se"    hgrid="ne30np4.pg4"  ncol="86400"   csne="30"  csnp="4" npg="4" />
 <horiz_grid dyn="se"    hgrid="ne60np4"      ncol="194402"  csne="60"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne60np4.pg2"  ncol="86400"   csne="60"  csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne120np4"     ncol="777602"  csne="120" csnp="4" npg="0" />

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -226,6 +226,7 @@
 <bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne30pg2_16xdel2-PFC-consistentSGH.c20190417.nc</bnd_topo>
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
+<bnd_topo hgrid="ne120np4" npg="2">atm/cam/topo/USGS-gtopo30_ne120pg2_16xdel2-PFC-consistentSGH.c20190819.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
 <bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH_20190212.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>

--- a/components/cam/src/control/cam_restart.F90
+++ b/components/cam/src/control/cam_restart.F90
@@ -303,10 +303,8 @@ end subroutine restart_printopts
       use time_manager,     only: timemgr_read_restart, timemgr_restart
       use filenames,        only: caseid, brnch_retain_casename
       use ref_pres,         only: ref_pres_init
-      use dyn_grid,         only: fv_nphys
       use ppgrid,           only: begchunk, endchunk, pcols
       use physics_types,    only: physics_type_alloc
-      use fv_physics_coupling_mod,  only: fv_phys_to_dyn_topo
       use cam_initfiles,            only: cam_initfiles_open
       use cam_initfiles,            only: topo_file_get_id
       use ncdio_atm,                only: infld
@@ -418,31 +416,6 @@ end subroutine restart_printopts
    call read_restart_dynamics(File, dyn_in, dyn_out, NLFileName)   
 
    call phys_grid_init
-
-   
-   if (fv_nphys>0) then
-    ! For FV physgrid we need allocate the phys_state before reading restart data
-    call physics_type_alloc(phys_state, phys_tend, begchunk, endchunk, pcols)
-
-    ! Read topo data from file when physics is on FV grid
-    call cam_initfiles_open()
-    fh_topo => topo_file_get_id()
-    nphys_sq = fv_nphys*fv_nphys
-    allocate(phis_tmp(nphys_sq,nelemd))
-    call infld('PHIS', fh_topo, 'ncol', 1, nphys_sq, 1, nelemd, phis_tmp, found, gridname='physgrid_d')
-    if(.not.found) call endrun('read_restart_dynamics(): Could not find PHIS field on input datafile')
-    ! Copy phis field to GLL grid
-    call fv_phys_to_dyn_topo(dyn_out%elem,phis_tmp)
-    deallocate(phis_tmp)
-    ! Do boundary exchange - weights applied in fv_phys_to_dyn_topo
-    do ie = 1,nelemd
-      call edgeVpack(edge_g,dyn_out%elem(ie)%state%phis(:,:),1,0,ie)
-    end do
-    if(par%dynproc) call bndry_exchangeV(par,edge_g)
-    do ie = 1,nelemd
-      call edgeVunpack(edge_g,dyn_out%elem(ie)%state%phis(:,:),1,0,ie)
-    end do
-  end if
 
    call hub2atm_alloc( cam_in )
    call atm2hub_alloc( cam_out )

--- a/components/cam/src/dynamics/se/dp_coupling.F90
+++ b/components/cam/src/dynamics/se/dp_coupling.F90
@@ -34,7 +34,6 @@ CONTAINS
   subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
     use physics_buffer,          only: physics_buffer_desc, pbuf_get_chunk, pbuf_get_field
     use shr_vmath_mod,           only: shr_vmath_exp
-    use time_manager,            only: is_first_step
     use cam_abortutils,          only: endrun
     use gravity_waves_sources,   only: gws_src_fnct
     use dyn_comp,                only: frontgf_idx, frontga_idx, hvcoord
@@ -185,18 +184,6 @@ CONTAINS
           phys_state(lchnk)%ps(icol)   = ps_tmp(ioff,ie)
           phys_state(lchnk)%phis(icol) = zs_tmp(ioff,ie)
           do ilyr = 1,pver
-            if (fv_nphys > 0) then
-              if (.not.is_first_step()) then
-                ! Tendencies are mapped rather than states, 
-                ! so we need to add in the previous state here
-                T_tmp(ioff,ilyr,ie)    = T_tmp(ioff,ilyr,ie)    + phys_state(lchnk)%t(icol,ilyr)
-                uv_tmp(ioff,1,ilyr,ie) = uv_tmp(ioff,1,ilyr,ie) + phys_state(lchnk)%u(icol,ilyr)
-                uv_tmp(ioff,2,ilyr,ie) = uv_tmp(ioff,2,ilyr,ie) + phys_state(lchnk)%v(icol,ilyr)
-                do m = 1,pcnst
-                  q_tmp(ioff,ilyr,m,ie) = q_tmp(ioff,ilyr,m,ie) + phys_state(lchnk)%q(icol,ilyr,m)
-                end do ! m
-              end if ! not is_first_step
-            end if ! fv_nphys > 0
             phys_state(lchnk)%t(icol,ilyr)     = T_tmp(ioff,ilyr,ie)	   
             phys_state(lchnk)%u(icol,ilyr)     = uv_tmp(ioff,1,ilyr,ie)
             phys_state(lchnk)%v(icol,ilyr)     = uv_tmp(ioff,2,ilyr,ie)
@@ -275,19 +262,6 @@ CONTAINS
           phys_state(lchnk)%ps  (icol) = cbuffer(cpter(icol,0))
           phys_state(lchnk)%phis(icol) = cbuffer(cpter(icol,0)+1)
           do ilyr = 1,pver
-            if (fv_nphys > 0) then
-              if (.not.is_first_step()) then
-                ! Tendencies are mapped rather than states, 
-                ! so we need to add in the previous state here
-                cbuffer(cpter(icol,ilyr)+0) = cbuffer(cpter(icol,ilyr)+0) + phys_state(lchnk)%t(icol,ilyr)
-                cbuffer(cpter(icol,ilyr)+1) = cbuffer(cpter(icol,ilyr)+1) + phys_state(lchnk)%u(icol,ilyr)
-                cbuffer(cpter(icol,ilyr)+2) = cbuffer(cpter(icol,ilyr)+2) + phys_state(lchnk)%v(icol,ilyr)
-                do m = 1,pcnst
-                  cbuffer(cpter(icol,ilyr)+tsize-pcnst-1+m) = cbuffer(cpter(icol,ilyr)+tsize-pcnst-1+m) &
-                                                             +phys_state(lchnk)%q(icol,ilyr,m)
-                end do ! m
-              end if ! not is_first_step
-            end if ! fv_nphys > 0
             phys_state(lchnk)%t    (icol,ilyr) = cbuffer(cpter(icol,ilyr))
             phys_state(lchnk)%u    (icol,ilyr) = cbuffer(cpter(icol,ilyr)+1)
             phys_state(lchnk)%v    (icol,ilyr) = cbuffer(cpter(icol,ilyr)+2)

--- a/components/cam/src/dynamics/se/fv_physics_coupling_mod.F90
+++ b/components/cam/src/dynamics/se/fv_physics_coupling_mod.F90
@@ -208,7 +208,6 @@ contains
     use derivative_mod,     only: subcell_integration
     use dyn_comp,           only: TimeLevel, hvcoord
     use element_ops,        only: get_temperature
-    use time_manager,       only: is_first_step
     implicit none
     !---------------------------------------------------------------------------
     ! interface arguments
@@ -280,42 +279,6 @@ contains
                                     np, fv_nphys, elem(ie)%metdet(:,:) )      &
                                     *inv_dp_fvm, (/ncol/) )
         end do
-
-        !-----------------------------------------------------------------------
-        ! Map previous dynamics state to physgrid for CRM forcing
-        !-----------------------------------------------------------------------
-        if (.not.is_first_step()) then
-
-          dp_gll_in(:,:) = elem(ie)%state%dp_in(:,:,ilyr)
-          inv_dp_fvm_in = 1.0 / subcell_integration(dp_gll_in,np,fv_nphys,elem(ie)%metdet(:,:))
-
-          T_tmp_in(:ncol)         = RESHAPE( subcell_integration(             &
-                                    elem(ie)%state%T_in(:,:,ilyr)*dp_gll_in,  &
-                                    np, fv_nphys, elem(ie)%metdet(:,:) )      &
-                                    *inv_dp_fvm_in, (/ncol/) )
-
-          do m = 1,pcnst
-            Q_tmp_in(:ncol,m)     = RESHAPE( subcell_integration(             &
-                                    elem(ie)%state%Q_in(:,:,ilyr,m)*dp_gll,   &
-                                    np, fv_nphys, elem(ie)%metdet(:,:) )      &
-                                    *inv_dp_fvm_in, (/ncol/) )
-          end do
-
-          do m = 1,2
-            uv_tmp_in(:ncol,m)    = RESHAPE( subcell_integration(             &
-                                    elem(ie)%state%V_in(:,:,m,ilyr),          &
-                                    np, fv_nphys, elem(ie)%metdet(:,:) )      &
-                                    *inv_area , (/ncol/) )
-          end do
-
-          ! Calculate tendency from mapped states
-          T_tmp (:ncol,ilyr,ie)   =  T_tmp(:ncol,ilyr,ie)   -  T_tmp_in(:ncol)
-          Q_tmp (:ncol,ilyr,:,ie) =  Q_tmp(:ncol,ilyr,:,ie) -  Q_tmp_in(:ncol,:)
-          uv_tmp(:ncol,:,ilyr,ie) = uv_tmp(:ncol,:,ilyr,ie) - uv_tmp_in(:ncol,:)
-
-        end if ! not is_first_step
-        !-----------------------------------------------------------------------
-        !-----------------------------------------------------------------------
 
       end do ! ilyr
     end do ! ie

--- a/components/cam/src/dynamics/se/inidat.F90
+++ b/components/cam/src/dynamics/se/inidat.F90
@@ -450,7 +450,6 @@ contains
              end do
           end do
     end do
-
     if ( (ideal_phys .or. aqua_planet)) then
        tmp(:,1,:) = 0._r8
        phis_tmp(:,:) = 0._r8
@@ -458,7 +457,7 @@ contains
       fieldname = 'PHIS'
       tmp(:,1,:) = 0.0_r8
       if (fv_nphys > 0) then
-         ! Load phis field to GLL grid first
+         ! Load phis field to physics grid
          call infld(fieldname, ncid_topo, 'ncol', 1, nphys_sq, &
               1, nelemd, phis_tmp, found, gridname='physgrid_d')
       else
@@ -471,13 +470,7 @@ contains
     end if
 
     if (fv_nphys == 0) then
-      ! Map phis data to FV physics grid
-      if (se_fv_phys_remap_alg == 0) then
-         call fv_phys_to_dyn_topo(elem,phis_tmp)
-      else
-         call gfr_fv_phys_to_dyn_topo(par, dom_mt, elem, phis_tmp)
-      end if
-      ! Copy phis data to element state
+      ! Copy phis data to dyn element state
       do ie=1,nelemd
          elem(ie)%state%phis=0.0_r8
          indx = 1
@@ -489,6 +482,13 @@ contains
             end do
          end do
       end do
+    else
+      ! Map phis data to dyn grid
+      if (se_fv_phys_remap_alg == 0) then
+         call fv_phys_to_dyn_topo(elem,phis_tmp)
+      else
+         call gfr_fv_phys_to_dyn_topo(par, dom_mt, elem, phis_tmp)
+      end if
     end if ! fv_nphys == 0
     
     if (single_column) then

--- a/components/cam/src/dynamics/se/restart_dynamics.F90
+++ b/components/cam/src/dynamics/se/restart_dynamics.F90
@@ -6,7 +6,7 @@ module restart_dynamics
   use spmd_utils,  only : iam
   use cam_logfile, only : iulog
   use control_mod, only : theta_hydrostatic_mode
-  use dyn_grid,    only : fv_nphys, fv_physgrid
+  ! use dyn_grid,    only : fv_nphys, fv_physgrid
 
   implicit none
 
@@ -87,16 +87,16 @@ CONTAINS
     end do
 
     ! Variables needed for mapping dyn tendencies to FV physics grid
-    if (fv_nphys>0) then
-      allocate( Q_in_desc(qsize_d) )
-      ierr = PIO_Def_Var(File, 'dyn_T_in', pio_double, (/ncol_dimid, nlev_dimid/), T_in_desc)
-      ierr = PIO_Def_Var(File, 'dyn_U_in', pio_double, (/ncol_dimid, nlev_dimid/), U_in_desc)
-      ierr = PIO_Def_Var(File, 'dyn_V_in', pio_double, (/ncol_dimid, nlev_dimid/), V_in_desc)
-      ierr = PIO_Def_Var(File, 'dyn_dp_in',pio_double, (/ncol_dimid, nlev_dimid/), dp_in_desc)
-      do i=1,qsize_d
-        ierr = PIO_Def_Var(File,'dyn_'//trim(cnst_name(i))//'_in', pio_double, (/ncol_dimid, nlev_dimid/), Q_in_desc(i))
-      end do
-    end if ! fv_nphys>0
+    ! if (fv_nphys>0) then
+    !   allocate( Q_in_desc(qsize_d) )
+    !   ierr = PIO_Def_Var(File, 'dyn_T_in', pio_double, (/ncol_dimid, nlev_dimid/), T_in_desc)
+    !   ierr = PIO_Def_Var(File, 'dyn_U_in', pio_double, (/ncol_dimid, nlev_dimid/), U_in_desc)
+    !   ierr = PIO_Def_Var(File, 'dyn_V_in', pio_double, (/ncol_dimid, nlev_dimid/), V_in_desc)
+    !   ierr = PIO_Def_Var(File, 'dyn_dp_in',pio_double, (/ncol_dimid, nlev_dimid/), dp_in_desc)
+    !   do i=1,qsize_d
+    !     ierr = PIO_Def_Var(File,'dyn_'//trim(cnst_name(i))//'_in', pio_double, (/ncol_dimid, nlev_dimid/), Q_in_desc(i))
+    !   end do
+    ! end if ! fv_nphys>0
 
   end subroutine init_restart_dynamics
 
@@ -202,76 +202,76 @@ CONTAINS
     !---------------------------------------------------------------------------
     ! Variables needed for mapping dyn tendencies to FV physics grid
     !---------------------------------------------------------------------------
-    if (fv_nphys>0) then
+!     if (fv_nphys>0) then
 
-      ! Write U_in
-!$omp parallel do private(ie, k, j, i)
-      do ie=1,nelemd
-        do k=1,nlev
-          do j=1,np
-            do i=1,np
-              var3d(i,j,ie,k) = elem(ie)%state%V_in(i,j,1,k)
-            end do
-          end do
-        end do
-      end do
-      call PIO_Write_Darray(File, U_in_desc, iodesc3d, var3d, ierr)
+!       ! Write U_in
+! !$omp parallel do private(ie, k, j, i)
+!       do ie=1,nelemd
+!         do k=1,nlev
+!           do j=1,np
+!             do i=1,np
+!               var3d(i,j,ie,k) = elem(ie)%state%V_in(i,j,1,k)
+!             end do
+!           end do
+!         end do
+!       end do
+!       call PIO_Write_Darray(File, U_in_desc, iodesc3d, var3d, ierr)
 
-      ! Write V_in
-!$omp parallel do private(ie, k, j, i)
-      do ie=1,nelemd
-        do k=1,nlev
-          do j=1,np
-            do i=1,np
-              var3d(i,j,ie,k) = elem(ie)%state%V_in(i,j,2,k)
-            end do
-          end do
-        end do
-      end do
-      call PIO_Write_Darray(File, V_in_desc, iodesc3d, var3d, ierr)
+!       ! Write V_in
+! !$omp parallel do private(ie, k, j, i)
+!       do ie=1,nelemd
+!         do k=1,nlev
+!           do j=1,np
+!             do i=1,np
+!               var3d(i,j,ie,k) = elem(ie)%state%V_in(i,j,2,k)
+!             end do
+!           end do
+!         end do
+!       end do
+!       call PIO_Write_Darray(File, V_in_desc, iodesc3d, var3d, ierr)
 
-      ! Write T_in
-!$omp parallel do private(ie, k, j, i) 
-      do ie=1,nelemd
-        do k=1,nlev
-          do j=1,np
-            do i=1,np
-              var3d(i,j,ie,k) = elem(ie)%state%T_in(i,j,k)
-            end do
-          end do
-        end do
-      end do
-      call PIO_Write_Darray(File, T_in_desc, iodesc3d, var3d, ierr)
+!       ! Write T_in
+! !$omp parallel do private(ie, k, j, i) 
+!       do ie=1,nelemd
+!         do k=1,nlev
+!           do j=1,np
+!             do i=1,np
+!               var3d(i,j,ie,k) = elem(ie)%state%T_in(i,j,k)
+!             end do
+!           end do
+!         end do
+!       end do
+!       call PIO_Write_Darray(File, T_in_desc, iodesc3d, var3d, ierr)
 
-      ! Write dp_in
-!$omp parallel do private(ie, k, j, i)
-      do ie=1,nelemd
-        do k=1,nlev
-          do j=1,np
-            do i=1,np
-              var3d(i,j,ie,k) = elem(ie)%state%dp_in(i,j,k)
-            end do
-          end do
-        end do
-      end do
-      call PIO_Write_Darray(File, dp_in_desc, iodesc3d, var3d, ierr)
+!       ! Write dp_in
+! !$omp parallel do private(ie, k, j, i)
+!       do ie=1,nelemd
+!         do k=1,nlev
+!           do j=1,np
+!             do i=1,np
+!               var3d(i,j,ie,k) = elem(ie)%state%dp_in(i,j,k)
+!             end do
+!           end do
+!         end do
+!       end do
+!       call PIO_Write_Darray(File, dp_in_desc, iodesc3d, var3d, ierr)
 
-      do q=1,qsize_d
-!$omp parallel do private(ie, k, j, i)
-        do ie=1,nelemd
-          do k=1,nlev
-            do j=1,np
-              do i=1,np
-                var3d(i,j,ie,k) = elem(ie)%state%Q_in(i,j,k,q)
-              end do
-            end do
-          end do
-        end do
-        call PIO_Write_Darray(File, Q_in_desc(q), iodesc3d, var3d, ierr)
-      end do
-      deallocate(Q_in_desc)
+!       do q=1,qsize_d
+! !$omp parallel do private(ie, k, j, i)
+!         do ie=1,nelemd
+!           do k=1,nlev
+!             do j=1,np
+!               do i=1,np
+!                 var3d(i,j,ie,k) = elem(ie)%state%Q_in(i,j,k,q)
+!               end do
+!             end do
+!           end do
+!         end do
+!         call PIO_Write_Darray(File, Q_in_desc(q), iodesc3d, var3d, ierr)
+!       end do
+!       deallocate(Q_in_desc)
 
-    end if ! fv_nphys>0
+!     end if ! fv_nphys>0
     !---------------------------------------------------------------------------
     !---------------------------------------------------------------------------
 
@@ -479,9 +479,6 @@ CONTAINS
     use spmd_dyn, only: spmd_readnl
     use control_mod,            only: qsplit
     use time_mod,               only: TimeLevel_Qdp
-    ! use fv_physics_coupling_mod,  only: fv_phys_to_dyn_topo
-    ! use cam_initfiles,            only: topo_file_get_id
-    ! use ncdio_atm,                only: infld
 
     !
     ! Input arguments
@@ -501,12 +498,6 @@ CONTAINS
     integer :: i, k, cnt, st, en, tl, tlQdp, ii, jj, s2d, q, j
     integer :: timelevel_dimid, timelevel_chk
     integer :: npes_se
-
-    ! integer :: nphys_sq
-    ! real(r8), allocatable :: phis_tmp(:,:) ! (nphys_sq,nelemd)
-    ! type(file_desc_t), pointer :: fh_topo
-    ! logical :: found
-
 !    type(file_desc_t) :: ncid
 !    integer :: ncid
 
@@ -521,18 +512,6 @@ CONTAINS
    else
     allocate (elem(0))
    endif
-
-    ! ! Read topo data from file when physics is on FV grid
-    ! if (fv_nphys>0) then
-    !   fh_topo => topo_file_get_id()
-    !   nphys_sq = fv_nphys*fv_nphys
-    !   allocate(phis_tmp(nphys_sq,nelemd))
-    !   call infld('PHIS', fh_topo, 'ncol', 1, nphys_sq, 1, nelemd, phis_tmp, found, gridname='physgrid_d')
-    !   if(.not.found) call endrun('read_restart_dynamics(): Could not find PHIS field on input datafile')
-    !   ! Copy phis field to GLL grid
-    !   call fv_phys_to_dyn_topo(elem,phis_tmp)
-    !   deallocate(phis_tmp)
-    ! end if
 
     ierr = PIO_Get_Att(File, PIO_GLOBAL, 'ne', fne)
     ierr = PIO_Get_Att(File, PIO_GLOBAL, 'np', fnp)
@@ -656,95 +635,95 @@ CONTAINS
     !---------------------------------------------------------------------------
     ! Variables needed for mapping dyn tendencies to FV physics grid
     !---------------------------------------------------------------------------
-    if (fv_nphys>0) then
+    ! if (fv_nphys>0) then
 
-      ierr = PIO_Inq_varid(File,'dyn_U_in', U_in_desc)
-      ierr = PIO_Inq_varid(File,'dyn_V_in', V_in_desc)
-      ierr = PIO_Inq_varid(File,'dyn_T_in', T_in_desc)
-      ierr = PIO_Inq_varid(File,'dyn_dp_in',dp_in_desc)
-      allocate( Q_in_desc(qsize_d) )
-      do q=1,qsize_d
-         ierr = PIO_Inq_varid(File, 'dyn_'//trim(cnst_name(q))//'_in' ,Q_in_desc(q))
-      end do
+    !   ierr = PIO_Inq_varid(File,'dyn_U_in', U_in_desc)
+    !   ierr = PIO_Inq_varid(File,'dyn_V_in', V_in_desc)
+    !   ierr = PIO_Inq_varid(File,'dyn_T_in', T_in_desc)
+    !   ierr = PIO_Inq_varid(File,'dyn_dp_in',dp_in_desc)
+    !   allocate( Q_in_desc(qsize_d) )
+    !   do q=1,qsize_d
+    !      ierr = PIO_Inq_varid(File, 'dyn_'//trim(cnst_name(q))//'_in' ,Q_in_desc(q))
+    !   end do
 
-      ! Switch to dyn_out for these variables
-      if (par%dynproc) elem=>dyn_out%elem
+    !   ! Switch to dyn_out for these variables
+    !   if (par%dynproc) elem=>dyn_out%elem
 
-      ! Read U_in
-      call PIO_Read_Darray(File, U_in_desc, iodesc3d, var3d, ierr)
-      cnt=0
-      do k=1,nlev
-        do ie=1,nelemd
-          do j=1,np
-            do i=1,np
-              cnt=cnt+1
-              elem(ie)%state%V_in(i,j,1,k) = var3d(cnt)
-            end do
-          end do
-        end do
-      end do
+    !   ! Read U_in
+    !   call PIO_Read_Darray(File, U_in_desc, iodesc3d, var3d, ierr)
+    !   cnt=0
+    !   do k=1,nlev
+    !     do ie=1,nelemd
+    !       do j=1,np
+    !         do i=1,np
+    !           cnt=cnt+1
+    !           elem(ie)%state%V_in(i,j,1,k) = var3d(cnt)
+    !         end do
+    !       end do
+    !     end do
+    !   end do
       
-      ! Read V_in
-      call PIO_Read_Darray(File, V_in_desc, iodesc3d, var3d, ierr)
-      cnt=0
-      do k=1,nlev
-        do ie=1,nelemd
-          do j=1,np
-            do i=1,np
-              cnt=cnt+1
-              elem(ie)%state%V_in(i,j,2,k) = var3d(cnt)
-            end do
-          end do
-        end do
-      end do
+    !   ! Read V_in
+    !   call PIO_Read_Darray(File, V_in_desc, iodesc3d, var3d, ierr)
+    !   cnt=0
+    !   do k=1,nlev
+    !     do ie=1,nelemd
+    !       do j=1,np
+    !         do i=1,np
+    !           cnt=cnt+1
+    !           elem(ie)%state%V_in(i,j,2,k) = var3d(cnt)
+    !         end do
+    !       end do
+    !     end do
+    !   end do
       
-      ! Read T_in
-      call PIO_Read_Darray(File, T_in_desc, iodesc3d, var3d, ierr)
-      cnt=0
-      do k=1,nlev
-        do ie=1,nelemd
-          do j=1,np
-            do i=1,np
-              cnt=cnt+1
-              elem(ie)%state%T_in(i,j,k) = var3d(cnt)
-            end do
-          end do
-        end do
-      end do
+    !   ! Read T_in
+    !   call PIO_Read_Darray(File, T_in_desc, iodesc3d, var3d, ierr)
+    !   cnt=0
+    !   do k=1,nlev
+    !     do ie=1,nelemd
+    !       do j=1,np
+    !         do i=1,np
+    !           cnt=cnt+1
+    !           elem(ie)%state%T_in(i,j,k) = var3d(cnt)
+    !         end do
+    !       end do
+    !     end do
+    !   end do
 
-      ! Read dp_in
-      call PIO_Read_Darray(File, dp_in_desc, iodesc3d, var3d, ierr)
-      cnt=0
-      do k=1,nlev
-        do ie=1,nelemd
-          do j=1,np
-            do i=1,np
-              cnt=cnt+1
-              elem(ie)%state%dp_in(i,j,k) = var3d(cnt)
-            end do
-          end do
-        end do
-      end do
+    !   ! Read dp_in
+    !   call PIO_Read_Darray(File, dp_in_desc, iodesc3d, var3d, ierr)
+    !   cnt=0
+    !   do k=1,nlev
+    !     do ie=1,nelemd
+    !       do j=1,np
+    !         do i=1,np
+    !           cnt=cnt+1
+    !           elem(ie)%state%dp_in(i,j,k) = var3d(cnt)
+    !         end do
+    !       end do
+    !     end do
+    !   end do
       
-      ! Read Q_in
-      do q=1,qsize_d
-        call PIO_Read_Darray(File, Q_in_desc(q), iodesc3d, var3d, ierr)
-        cnt=0
-        do k=1,nlev
-          do ie=1,nelemd
-            do j=1,np
-              do i=1,np
-                cnt=cnt+1
-                elem(ie)%state%Q_in(i,j,k,q) = var3d(cnt)
-              end do
-            end do
-          end do
-        end do
+    !   ! Read Q_in
+    !   do q=1,qsize_d
+    !     call PIO_Read_Darray(File, Q_in_desc(q), iodesc3d, var3d, ierr)
+    !     cnt=0
+    !     do k=1,nlev
+    !       do ie=1,nelemd
+    !         do j=1,np
+    !           do i=1,np
+    !             cnt=cnt+1
+    !             elem(ie)%state%Q_in(i,j,k,q) = var3d(cnt)
+    !           end do
+    !         end do
+    !       end do
+    !     end do
 
-      end do
-      deallocate(Q_in_desc)
+    !   end do
+    !   deallocate(Q_in_desc)
 
-    end if ! fv_nphys>0
+    ! end if ! fv_nphys>0
     !---------------------------------------------------------------------------
     !---------------------------------------------------------------------------
 

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -409,27 +409,6 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out )
    call t_stopf('stepon_bndry_exch')
 
 
-   ! copy current dyn state + phys tend for mapping tendencies back to FV phys grid 
-   if (par%dynproc) then
-      if (fv_nphys > 0) then
-         do ie = 1,nelemd
-            call get_temperature(dyn_in%elem(ie),temperature,hvcoord,tl_f)
-            dyn_out%elem(ie)%state%T_in    = temperature & 
-                                            +dyn_in%elem(ie)%derived%fT(:,:,:)*dtime
-            dyn_out%elem(ie)%state%V_in    = dyn_in%elem(ie)%state%v(:,:,:,:,TimeLevel%n0) &
-                                            +dyn_in%elem(ie)%derived%fM(:,:,:,:)*dtime
-            if ( (ftype==2) .or. (ftype==4) ) then
-              dyn_out%elem(ie)%state%Q_in  = dyn_in%elem(ie)%state%q(:,:,:,:)
-            else
-              dyn_out%elem(ie)%state%Q_in  = dyn_in%elem(ie)%state%q(:,:,:,:) &
-                                            +dyn_in%elem(ie)%derived%fQ(:,:,:,:)*dtime
-            end if
-            dyn_out%elem(ie)%state%dp_in   = dyn_in%elem(ie)%state%dp3d(:,:,:,TimeLevel%n0)
-         end do
-      end if ! fv_nphys > 0
-   end if ! par%dynproc
-
-
    ! Most output is done by physics.  We pass to the physics state variables
    ! at timelevel "tl_f".  
    ! we will output dycore variables here to ensure they are always at the same

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -784,7 +784,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     call phys_getopts(use_SPCAM_out     = use_SPCAM)
 
-    if (fv_nphys==0 .or. nsrest==0) call physics_type_alloc(phys_state, phys_tend, begchunk, endchunk, pcols)
+    call physics_type_alloc(phys_state, phys_tend, begchunk, endchunk, pcols)
 
     do lchnk = begchunk, endchunk
        call physics_state_set_grid(lchnk, phys_state(lchnk))

--- a/components/cam/src/physics/cam/restart_physics.F90
+++ b/components/cam/src/physics/cam/restart_physics.F90
@@ -20,7 +20,7 @@ module restart_physics
   use cospsimulator_intr, only: docosp
   use radiation,          only: cosp_cnt_init, cosp_cnt, rad_randn_seedrst, kiss_seed_num
   use physics_types,      only: physics_state
-  use dyn_grid,           only: fv_nphys
+  ! use dyn_grid,           only: fv_nphys
 
   implicit none
   private
@@ -206,15 +206,15 @@ module restart_physics
     endif
 
     ! phys_state variables are needed for mapping to FV physics grid on restart
-    if (fv_nphys>0) then
-      dimids(hdimcnt+1) = pver_id
-      ierr = pio_def_var(File, 'phys_T', pio_double, dimids(1:hdimcnt+1), T_desc)
-      ierr = pio_def_var(File, 'phys_U', pio_double, dimids(1:hdimcnt+1), U_desc)
-      ierr = pio_def_var(File, 'phys_V', pio_double, dimids(1:hdimcnt+1), V_desc)
-      do i=1,pcnst
-        ierr = pio_def_var(File,'phys_'//trim(cnst_name(i)), pio_double, dimids(1:hdimcnt+1), Q_desc(i))
-      end do
-    end if ! fv_nphys>0
+    ! if (fv_nphys>0) then
+    !   dimids(hdimcnt+1) = pver_id
+    !   ierr = pio_def_var(File, 'phys_T', pio_double, dimids(1:hdimcnt+1), T_desc)
+    !   ierr = pio_def_var(File, 'phys_U', pio_double, dimids(1:hdimcnt+1), U_desc)
+    !   ierr = pio_def_var(File, 'phys_V', pio_double, dimids(1:hdimcnt+1), V_desc)
+    !   do i=1,pcnst
+    !     ierr = pio_def_var(File,'phys_'//trim(cnst_name(i)), pio_double, dimids(1:hdimcnt+1), Q_desc(i))
+    !   end do
+    ! end if ! fv_nphys>0
       
   end subroutine init_restart_physics
 
@@ -500,52 +500,52 @@ module restart_physics
     !---------------------------------------------------------------------------
     ! phys_state variables are needed for mapping to FV physics grid on restart
     !---------------------------------------------------------------------------
-    if (fv_nphys>0) then
+    ! if (fv_nphys>0) then
 
-      dims(1) = pcols
-      dims(2) = pver
-      dims(3) = endchunk - begchunk + 1
-      gdims(nhdims+1) = pver
+    !   dims(1) = pcols
+    !   dims(2) = pver
+    !   dims(3) = endchunk - begchunk + 1
+    !   gdims(nhdims+1) = pver
 
-      ! write U
-      do i = begchunk, endchunk
-        ncol = cam_in(i)%ncol
-        do k = 1,pver
-          tmpfield3d(:ncol,k,i) = phys_state(i)%u(:ncol,k)
-        end do
-      end do
-      call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,U_desc)
+    !   ! write U
+    !   do i = begchunk, endchunk
+    !     ncol = cam_in(i)%ncol
+    !     do k = 1,pver
+    !       tmpfield3d(:ncol,k,i) = phys_state(i)%u(:ncol,k)
+    !     end do
+    !   end do
+    !   call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,U_desc)
 
-      ! write V
-      do i = begchunk, endchunk
-        ncol = cam_in(i)%ncol
-        do k = 1,pver
-          tmpfield3d(:ncol,k,i) = phys_state(i)%v(:ncol,k)
-        end do
-      end do
-      call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,V_desc)
+    !   ! write V
+    !   do i = begchunk, endchunk
+    !     ncol = cam_in(i)%ncol
+    !     do k = 1,pver
+    !       tmpfield3d(:ncol,k,i) = phys_state(i)%v(:ncol,k)
+    !     end do
+    !   end do
+    !   call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,V_desc)
 
-      ! write T
-      do i = begchunk, endchunk
-        ncol = cam_in(i)%ncol
-        do k = 1,pver
-          tmpfield3d(:ncol,k,i) = phys_state(i)%t(:ncol,k)
-        end do
-      end do
-      call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,T_desc)
+    !   ! write T
+    !   do i = begchunk, endchunk
+    !     ncol = cam_in(i)%ncol
+    !     do k = 1,pver
+    !       tmpfield3d(:ncol,k,i) = phys_state(i)%t(:ncol,k)
+    !     end do
+    !   end do
+    !   call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,T_desc)
 
-      ! write Q
-      do m = 1,pcnst
-        do i = begchunk, endchunk
-          ncol = cam_in(i)%ncol
-          do k = 1,pver
-            tmpfield3d(:ncol,k,i) = phys_state(i)%q(:ncol,k,m)
-          end do
-        end do
-        call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,Q_desc(m))
-      end do ! m
+    !   ! write Q
+    !   do m = 1,pcnst
+    !     do i = begchunk, endchunk
+    !       ncol = cam_in(i)%ncol
+    !       do k = 1,pver
+    !         tmpfield3d(:ncol,k,i) = phys_state(i)%q(:ncol,k,m)
+    !       end do
+    !     end do
+    !     call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,Q_desc(m))
+    !   end do ! m
 
-    end if ! fv_nphys>0
+    ! end if ! fv_nphys>0
     !---------------------------------------------------------------------------
     !---------------------------------------------------------------------------
       
@@ -907,81 +907,81 @@ module restart_physics
       !---------------------------------------------------------------------------
       ! phys_state variables are needed for mapping to FV physics grid on restart
       !---------------------------------------------------------------------------
-      if (fv_nphys>0) then
+      ! if (fv_nphys>0) then
 
-         dims(1) = pcols
-         dims(2) = pver
-         dims(3) = csize
-         gdims(nhdims+1) = dims(2)
+      !    dims(1) = pcols
+      !    dims(2) = pver
+      !    dims(3) = csize
+      !    gdims(nhdims+1) = dims(2)
 
-         allocate(tmpfield3(pcols, pver, begchunk:endchunk))
-         tmpfield3 = fillvalue
+      !    allocate(tmpfield3(pcols, pver, begchunk:endchunk))
+      !    tmpfield3 = fillvalue
 
-         ! read U
-         ierr = pio_inq_varid(File, 'phys_U', vardesc)
-         if(ierr == PIO_NOERR) then
-            call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-            do c = begchunk, endchunk
-               do k = 1,pver
-                  do i = 1,pcols
-                     phys_state(c)%u(i,k) = tmpfield3(i,k,c)
-                  end do
-               end do
-            end do
-         else
-            if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_U in restart file; ierr = ',ierr
-         end if
+      !    ! read U
+      !    ierr = pio_inq_varid(File, 'phys_U', vardesc)
+      !    if(ierr == PIO_NOERR) then
+      !       call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
+      !       do c = begchunk, endchunk
+      !          do k = 1,pver
+      !             do i = 1,pcols
+      !                phys_state(c)%u(i,k) = tmpfield3(i,k,c)
+      !             end do
+      !          end do
+      !       end do
+      !    else
+      !       if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_U in restart file; ierr = ',ierr
+      !    end if
 
-         ! read V
-         ierr = pio_inq_varid(File, 'phys_V', vardesc)
-         if(ierr == PIO_NOERR) then
-            call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-            do c = begchunk, endchunk
-               do k = 1,pver
-                  do i = 1,pcols
-                     phys_state(c)%v(i,k) = tmpfield3(i,k,c)
-                  end do
-               end do
-            end do
-         else
-            if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_V in restart file; ierr = ',ierr
-         end if
+      !    ! read V
+      !    ierr = pio_inq_varid(File, 'phys_V', vardesc)
+      !    if(ierr == PIO_NOERR) then
+      !       call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
+      !       do c = begchunk, endchunk
+      !          do k = 1,pver
+      !             do i = 1,pcols
+      !                phys_state(c)%v(i,k) = tmpfield3(i,k,c)
+      !             end do
+      !          end do
+      !       end do
+      !    else
+      !       if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_V in restart file; ierr = ',ierr
+      !    end if
 
-         ! read T
-         ierr = pio_inq_varid(File, 'phys_T', vardesc)
-         if(ierr == PIO_NOERR) then
-            call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-            do c = begchunk, endchunk
-               do k = 1,pver
-                  do i = 1,pcols
-                     phys_state(c)%t(i,k) = tmpfield3(i,k,c)
-                  end do
-               end do
-            end do
-         else
-            if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_T in restart file; ierr = ',ierr
-         end if
+      !    ! read T
+      !    ierr = pio_inq_varid(File, 'phys_T', vardesc)
+      !    if(ierr == PIO_NOERR) then
+      !       call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
+      !       do c = begchunk, endchunk
+      !          do k = 1,pver
+      !             do i = 1,pcols
+      !                phys_state(c)%t(i,k) = tmpfield3(i,k,c)
+      !             end do
+      !          end do
+      !       end do
+      !    else
+      !       if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_T in restart file; ierr = ',ierr
+      !    end if
 
-         ! read Q
-         do m = 1,pcnst
-            ierr = pio_inq_varid(File, 'phys_'//trim(cnst_name(m)), vardesc)
-            if(ierr == PIO_NOERR) then
-               call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-               do c = begchunk, endchunk
-                  do k = 1,pver
-                     do i = 1,pcols
-                        phys_state(c)%q(i,k,m) = tmpfield3(i,k,c)
-                     end do
-                  end do
-               end do
-            else
-               if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_'//trim(cnst_name(m))//' in restart file; ierr = ',ierr
-            end if
-         end do ! m
+      !    ! read Q
+      !    do m = 1,pcnst
+      !       ierr = pio_inq_varid(File, 'phys_'//trim(cnst_name(m)), vardesc)
+      !       if(ierr == PIO_NOERR) then
+      !          call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
+      !          do c = begchunk, endchunk
+      !             do k = 1,pver
+      !                do i = 1,pcols
+      !                   phys_state(c)%q(i,k,m) = tmpfield3(i,k,c)
+      !                end do
+      !             end do
+      !          end do
+      !       else
+      !          if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_'//trim(cnst_name(m))//' in restart file; ierr = ',ierr
+      !       end if
+      !    end do ! m
 
-         deallocate(tmpfield3)
+      !    deallocate(tmpfield3)
 
-      end if ! fv_nphys>0
+      ! end if ! fv_nphys>0
       !---------------------------------------------------------------------------
       !---------------------------------------------------------------------------
 

--- a/components/cam/src/physics/cam/restart_physics.F90
+++ b/components/cam/src/physics/cam/restart_physics.F90
@@ -20,7 +20,6 @@ module restart_physics
   use cospsimulator_intr, only: docosp
   use radiation,          only: cosp_cnt_init, cosp_cnt, rad_randn_seedrst, kiss_seed_num
   use physics_types,      only: physics_state
-  ! use dyn_grid,           only: fv_nphys
 
   implicit none
   private
@@ -205,16 +204,6 @@ module restart_physics
        ierr = pio_def_var(File, 'rad_randn_seedrst', pio_int, dimids(1:hdimcnt+1), rad_randn_seedrst_desc)
     endif
 
-    ! phys_state variables are needed for mapping to FV physics grid on restart
-    ! if (fv_nphys>0) then
-    !   dimids(hdimcnt+1) = pver_id
-    !   ierr = pio_def_var(File, 'phys_T', pio_double, dimids(1:hdimcnt+1), T_desc)
-    !   ierr = pio_def_var(File, 'phys_U', pio_double, dimids(1:hdimcnt+1), U_desc)
-    !   ierr = pio_def_var(File, 'phys_V', pio_double, dimids(1:hdimcnt+1), V_desc)
-    !   do i=1,pcnst
-    !     ierr = pio_def_var(File,'phys_'//trim(cnst_name(i)), pio_double, dimids(1:hdimcnt+1), Q_desc(i))
-    !   end do
-    ! end if ! fv_nphys>0
       
   end subroutine init_restart_physics
 
@@ -497,57 +486,6 @@ module restart_physics
               gdims(1:nhdims+1), tmp_seedrst, rad_randn_seedrst_desc)
       endif
 
-    !---------------------------------------------------------------------------
-    ! phys_state variables are needed for mapping to FV physics grid on restart
-    !---------------------------------------------------------------------------
-    ! if (fv_nphys>0) then
-
-    !   dims(1) = pcols
-    !   dims(2) = pver
-    !   dims(3) = endchunk - begchunk + 1
-    !   gdims(nhdims+1) = pver
-
-    !   ! write U
-    !   do i = begchunk, endchunk
-    !     ncol = cam_in(i)%ncol
-    !     do k = 1,pver
-    !       tmpfield3d(:ncol,k,i) = phys_state(i)%u(:ncol,k)
-    !     end do
-    !   end do
-    !   call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,U_desc)
-
-    !   ! write V
-    !   do i = begchunk, endchunk
-    !     ncol = cam_in(i)%ncol
-    !     do k = 1,pver
-    !       tmpfield3d(:ncol,k,i) = phys_state(i)%v(:ncol,k)
-    !     end do
-    !   end do
-    !   call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,V_desc)
-
-    !   ! write T
-    !   do i = begchunk, endchunk
-    !     ncol = cam_in(i)%ncol
-    !     do k = 1,pver
-    !       tmpfield3d(:ncol,k,i) = phys_state(i)%t(:ncol,k)
-    !     end do
-    !   end do
-    !   call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,T_desc)
-
-    !   ! write Q
-    !   do m = 1,pcnst
-    !     do i = begchunk, endchunk
-    !       ncol = cam_in(i)%ncol
-    !       do k = 1,pver
-    !         tmpfield3d(:ncol,k,i) = phys_state(i)%q(:ncol,k,m)
-    !       end do
-    !     end do
-    !     call cam_grid_write_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3d,Q_desc(m))
-    !   end do ! m
-
-    ! end if ! fv_nphys>0
-    !---------------------------------------------------------------------------
-    !---------------------------------------------------------------------------
       
     end subroutine write_restart_physics
 
@@ -904,86 +842,6 @@ module restart_physics
         endif
      endif
 
-      !---------------------------------------------------------------------------
-      ! phys_state variables are needed for mapping to FV physics grid on restart
-      !---------------------------------------------------------------------------
-      ! if (fv_nphys>0) then
-
-      !    dims(1) = pcols
-      !    dims(2) = pver
-      !    dims(3) = csize
-      !    gdims(nhdims+1) = dims(2)
-
-      !    allocate(tmpfield3(pcols, pver, begchunk:endchunk))
-      !    tmpfield3 = fillvalue
-
-      !    ! read U
-      !    ierr = pio_inq_varid(File, 'phys_U', vardesc)
-      !    if(ierr == PIO_NOERR) then
-      !       call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-      !       do c = begchunk, endchunk
-      !          do k = 1,pver
-      !             do i = 1,pcols
-      !                phys_state(c)%u(i,k) = tmpfield3(i,k,c)
-      !             end do
-      !          end do
-      !       end do
-      !    else
-      !       if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_U in restart file; ierr = ',ierr
-      !    end if
-
-      !    ! read V
-      !    ierr = pio_inq_varid(File, 'phys_V', vardesc)
-      !    if(ierr == PIO_NOERR) then
-      !       call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-      !       do c = begchunk, endchunk
-      !          do k = 1,pver
-      !             do i = 1,pcols
-      !                phys_state(c)%v(i,k) = tmpfield3(i,k,c)
-      !             end do
-      !          end do
-      !       end do
-      !    else
-      !       if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_V in restart file; ierr = ',ierr
-      !    end if
-
-      !    ! read T
-      !    ierr = pio_inq_varid(File, 'phys_T', vardesc)
-      !    if(ierr == PIO_NOERR) then
-      !       call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-      !       do c = begchunk, endchunk
-      !          do k = 1,pver
-      !             do i = 1,pcols
-      !                phys_state(c)%t(i,k) = tmpfield3(i,k,c)
-      !             end do
-      !          end do
-      !       end do
-      !    else
-      !       if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_T in restart file; ierr = ',ierr
-      !    end if
-
-      !    ! read Q
-      !    do m = 1,pcnst
-      !       ierr = pio_inq_varid(File, 'phys_'//trim(cnst_name(m)), vardesc)
-      !       if(ierr == PIO_NOERR) then
-      !          call cam_grid_read_dist_array(File,physgrid,dims(1:3),gdims(1:nhdims+1),tmpfield3,vardesc)
-      !          do c = begchunk, endchunk
-      !             do k = 1,pver
-      !                do i = 1,pcols
-      !                   phys_state(c)%q(i,k,m) = tmpfield3(i,k,c)
-      !                end do
-      !             end do
-      !          end do
-      !       else
-      !          if(masterproc) write(iulog,*) 'read_restart_physics: unable to find phys_'//trim(cnst_name(m))//' in restart file; ierr = ',ierr
-      !       end if
-      !    end do ! m
-
-      !    deallocate(tmpfield3)
-
-      ! end if ! fv_nphys>0
-      !---------------------------------------------------------------------------
-      !---------------------------------------------------------------------------
 
    end subroutine read_restart_physics
 

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -229,6 +229,8 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2000_c190730.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr2000_c190408.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2000_c160309.nc</fsurdat>
+<fsurdat hgrid="ne120np4.pg2" sim_year="2000" >
+lnd/clm2/surfdata_map/surfdata_ne120pg2_simyr2000_c190815.nc</fsurdat>
 <fsurdat hgrid="ne16np4"      sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne16np4_simyr2000_c160108.nc</fsurdat>
 <fsurdat hgrid="ne11np4"      sim_year="2000" use_crop=".false." >

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1206,7 +1206,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 

--- a/components/homme/src/preqx/element_state.F90
+++ b/components/homme/src/preqx/element_state.F90
@@ -29,13 +29,6 @@ module element_state
     real (kind=real_kind) :: Q   (np,np,nlev,qsize_d)                 ! Tracer concentration               6
     real (kind=real_kind) :: Qdp (np,np,nlev,qsize_d,2)               ! Tracer mass                        7
 
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
-
   end type elem_state_t
 
   !___________________________________________________________________

--- a/components/homme/src/preqx_acc/element_state.F90
+++ b/components/homme/src/preqx_acc/element_state.F90
@@ -30,13 +30,6 @@ module element_state
     real (kind=real_kind) :: phis(np,np)                              ! surface geopotential (prescribed)  5
     real (kind=real_kind) :: Q   (np,np,nlev,qsize_d)                 ! Tracer concentration               6
     real (kind=real_kind), pointer :: Qdp (:,:,:,:,:)  ! Tracer mass                        7  (np,np,nlev,qsize,2)   
-
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
     
   end type elem_state_t
 

--- a/components/homme/src/preqx_kokkos/element_state.F90
+++ b/components/homme/src/preqx_kokkos/element_state.F90
@@ -53,13 +53,6 @@ module element_state
 
     real (kind=real_kind), pointer :: phis (:,:)                  ! surface geopotential (prescribed)  5
 
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
-
   end type elem_state_t
 
   !___________________________________________________________________

--- a/components/homme/src/prim/element_state.F90
+++ b/components/homme/src/prim/element_state.F90
@@ -29,13 +29,6 @@ module element_state
     real (kind=real_kind) :: Q   (np,np,nlev,qsize_d)                 ! Tracer concentration               6
     real (kind=real_kind) :: Qdp (np,np,nlev,qsize_d,2)               ! Tracer mass                        7
 
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
-
   end type elem_state_t
 
   !___________________________________________________________________

--- a/components/homme/src/sweqx/element_state.F90
+++ b/components/homme/src/sweqx/element_state.F90
@@ -20,13 +20,6 @@ module element_state
      real (kind=real_kind) :: gradps(np,np,2)                         ! gradient of surface geopotential
      real (kind=real_kind) :: v(np,np,2,nlev,timelevels)              ! contravarient comp
 
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
-
   end type elem_state_t
 
   !___________________________________________________________________

--- a/components/homme/src/swim/element_state.F90
+++ b/components/homme/src/swim/element_state.F90
@@ -20,13 +20,6 @@ module element_state
      real (kind=real_kind) :: gradps(np,np,2)                         ! gradient of surface geopotential
      real (kind=real_kind) :: v(np,np,2,nlev,timelevels)              ! contravarient comp
 
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
-
   end type elem_state_t
 
   !___________________________________________________________________

--- a/components/homme/src/theta-l/element_state.F90
+++ b/components/homme/src/theta-l/element_state.F90
@@ -48,13 +48,6 @@ module element_state
     real (kind=real_kind) :: Q   (np,np,nlev,qsize_d)             ! Tracer concentration               
     real (kind=real_kind) :: Qdp (np,np,nlev,qsize_d,2)           ! Tracer mass                        
 
-    ! Variables for incoming dynamics state used to calculate 
-    ! dynamics tendencies to physics when fv_nphys>0
-    real (kind=real_kind) :: T_in  (np,np,nlev)         ! temperature
-    real (kind=real_kind) :: V_in  (np,np,2,nlev)       ! velocity
-    real (kind=real_kind) :: Q_in  (np,np,nlev,qsize_d) ! Tracer concentration
-    real (kind=real_kind) :: dp_in (np,np,nlev)         ! pressure thickness
-
   end type elem_state_t
 
   !___________________________________________________________________


### PR DESCRIPTION
This includes some fixes to restore physgrid capability. Most important, the 2-way tendency mapping that was originally added when physgrid was merged to ECP is removed, including several restart file variables. This PR also includes a fix for a restart bug when running aquaplanet cases with the physgrid and support for the ne120pg grid. There is also partial support added for some other girds (ne4pg3, ne4pg4, ne30pg3, ne30pg4) which are not planned for serious use, but are useful for testing and may likely be removed later.