### PR TITLE
Fix build machine and compiler configuration files on summit with IBM compiler

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1791,6 +1791,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <FC_AUTO_R8>
+    <base> -qrealsize=8 </base>
+  </FC_AUTO_R8>
 </compiler>
 
 <compiler MACH="summit" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3017,7 +3017,8 @@
       <command name="load">cuda</command>
     </modules>
     <modules compiler="ibm">
-      <command name="load">xl/16.1.1-1</command>
+      <command name="load">xalt/1.1.4</command>
+      <command name="load">xl/16.1.1-3</command>
     </modules>
     <modules compiler="gnu">
       <command name="load">gcc/6.4.0</command>


### PR DESCRIPTION
Adding a new module dependency (xalt/1.1.4) for the XL compiler. Without this change netcdf/pnetcdf modules fail to load with the XL compiler

[BFB]