### PR TITLE
Adding a new module dependency (xalt/1.1.4) for the XL compiler. Without this change netcdf/pnetcdf modules fail to load with the XL compiler

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1791,9 +1791,6 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-  <FC_AUTO_R8>
-    <base> -qrealsize=8 </base>
-  </FC_AUTO_R8>
 </compiler>
 
 <compiler MACH="summit" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1791,6 +1791,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <FC_AUTO_R8>
+    <base> -qrealsize=8 </base>
+  </FC_AUTO_R8>
 </compiler>
 
 <compiler MACH="summit" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3017,7 +3017,8 @@
       <command name="load">cuda</command>
     </modules>
     <modules compiler="ibm">
-      <command name="load">xl/16.1.1-1</command>
+      <command name="load">xalt/1.1.4</command>
+      <command name="load">xl/16.1.1-3</command>
     </modules>
     <modules compiler="gnu">
       <command name="load">gcc/6.4.0</command>

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -374,7 +374,7 @@ MODULE WRM_subw_IO_mod
            enddo
         enddo
         if (cnt /= cntw) then
-           write(iulog,"(a,3i8)"), subname//'ERROR: sMat g2d cnt errora',cntw,cnt
+           write(iulog,"(a,3i8)") subname//'ERROR: sMat g2d cnt errora',cntw,cnt
            call shr_sys_abort(subname//' ERROR: sMat g2d cnt errora')
         endif
 
@@ -396,7 +396,7 @@ MODULE WRM_subw_IO_mod
            enddo
         enddo
         if (cnt /= cntw) then
-           write(iulog,"(a,3i8)"), subname//'ERROR: sMat d2g cnt errora',cntw,cnt
+           write(iulog,"(a,3i8)") subname//'ERROR: sMat d2g cnt errora',cntw,cnt
            call shr_sys_abort(subname//' ERROR: sMat d2g cnt errora')
         endif
 
@@ -422,7 +422,7 @@ MODULE WRM_subw_IO_mod
               enddo
            enddo
            if (cnt /= cntg) then
-              write(iulog,"(a,3i8)"), subname//'ERROR: sMat g2d cnt errorb',cntg,cnt
+              write(iulog,"(a,3i8)") subname//'ERROR: sMat g2d cnt errorb',cntg,cnt
               call shr_sys_abort(subname//' ERROR: sMat g2d cnt errorb')
            endif
         else
@@ -448,7 +448,7 @@ MODULE WRM_subw_IO_mod
               enddo
            enddo
            if (cnt /= cntg) then
-              write(iulog,"(a,3i8)"), subname//'ERROR: sMat d2g cnt errorb',cntg,cnt
+              write(iulog,"(a,3i8)") subname//'ERROR: sMat d2g cnt errorb',cntg,cnt
               call shr_sys_abort(subname//' ERROR: sMat d2g cnt errorb')
            endif
         else


### PR DESCRIPTION
Adding a new module dependency (xalt/1.1.4) for the XL compiler. Without this change netcdf/pnetcdf modules fail to load with the XL compiler

[BFB]