### PR TITLE
Adding a new module dependency (xalt/1.1.4)

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3017,7 +3017,8 @@
       <command name="load">cuda</command>
     </modules>
     <modules compiler="ibm">
-      <command name="load">xl/16.1.1-1</command>
+      <command name="load">xalt/1.1.4</command>
+      <command name="load">xl/16.1.1-3</command>
     </modules>
     <modules compiler="gnu">
       <command name="load">gcc/6.4.0</command>


### PR DESCRIPTION
Add a new module dependency (xalt/1.1.4) for the XL compiler, and update xl compiler version 16.1.1-1 to 16.1.1-3, Without this change netcdf/pnetcdf modules fail to load with the XL compiler.

[BFB]