### PR TITLE
Make SP_MCICA_RAD default behavior for SP

### DIFF
--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -99,7 +99,7 @@
       <!-- Super-Parameterization -->
       <value compset="_CAM5%SP[12]V1"        >-use_SPCAM -crm_adv MPDATA -nlev 72 -crm_nz 58 -crm_dx 1000 -crm_dt 5 </value>
       <value compset="_CAM5%SP[12]V1"        >-microphys mg2  </value>
-      <value compset="_CAM5%SP[12]V1"        >-cppdefs ' -DSP_DIR_NS -DSP_MCICA_RAD ' </value>
+      <value compset="_CAM5%SP[12]V1"        >-cppdefs ' -DSP_DIR_NS ' </value>
       <value compset="_CAM5%SP[12]V1"        >-rad rrtmg </value>
       <value compset="_CAM5%SP1V1"           >-SPCAM_microp_scheme sam1mom -chem none </value>
       <value compset="_CAM5%SP2V1"           >-SPCAM_microp_scheme m2005 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
@@ -109,7 +109,7 @@
       <value compset="_CAM5%SP2V1-ECPP"      >-use_ECPP </value>
       <!-- Fast SP compset for development -->
       <value compset="_CAM5%SP[12]FAST"      >-use_SPCAM -crm_adv MPDATA -nlev 30 -crm_nz 28 -crm_dx 4000 -crm_dt 20 </value>
-      <value compset="_CAM5%SP[12]FAST"      >-microphys mg2 -cppdefs ' -DSP_DIR_NS -DSP_MCICA_RAD ' -rad rrtmg      </value>
+      <value compset="_CAM5%SP[12]FAST"      >-microphys mg2 -cppdefs ' -DSP_DIR_NS ' -rad rrtmg      </value>
       <value compset="_CAM5%SP1FAST"         >-crm_nx 4 -crm_ny 4 -crm_nx_rad 1 -crm_ny_rad 1 -SPCAM_microp_scheme sam1mom  -chem none </value>
       <value compset="_CAM5%SP2FAST"         >-crm_nx 6 -crm_ny 1 -crm_nx_rad 1 -crm_ny_rad 1 -SPCAM_microp_scheme m2005    -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -use_ECPP </value>
       <!--  -->

--- a/components/cam/src/physics/rrtmg/radiation.F90
+++ b/components/cam/src/physics/rrtmg/radiation.F90
@@ -1269,9 +1269,6 @@ end function radiation_nextsw_cday
     real(r8) ::  aerindex(pcols)      ! Aerosol index
     integer aod400_idx, aod700_idx, cld_tau_idx
 
-    ! Total cloud water threshold for considering a CRM column "cloudy" or "clear"
-    real(r8), parameter :: qtot_cld_threshold = 1.e-9
-
     character(*), parameter :: name = 'radiation_tend'
     character(len=16)       :: SPCAM_microp_scheme  ! SPCAM_microphysics scheme
 !----------------------------------------------------------------------
@@ -1584,29 +1581,12 @@ end function radiation_nextsw_cday
               k = pver-m+1
               do i=1,ncol
 
-                ! Calculate cloud fraction and in-cloud water paths. Cloud fraction can either be
-                ! adopted from the calculation done within the CRM integration or can be calculated
-                ! here based on a total water threshold, assuming that the CRM element is "cloudy"
-                ! if the total water exceeds some threshold (set arbitrarily here), and is "clear"
-                ! otherwise. Note that setting cloud fraction to 0 or 1 based on the total water
-                ! threshold effectively turns OFF MCICA sampling in the cloud optics routines. This
-                ! may be undesireable, especially for longer radiation update intervals (iradsw and
-                ! iradlw > 1 or longer physics timesteps) or when using the reduced radiation
-                ! option in which we average cloud properties over some number of CRM columns. In
-                ! both of these cases, the assumption that clouds are fully resolved on the time and
-                ! space scales that the radiation sees becomes less reasonable.
-                qtot = qc_rad(i,ii,jj,m) + qi_rad(i,ii,jj,m)
-#ifdef SP_MCICA_RAD
+                ! Overwrite cloud fraction with CRM cloud fraction
                 cld(i,k) = cld_rad(i,ii,jj,m)
-#else
-                if(qtot > qtot_cld_threshold) then
-                    cld(i,k) = 0.99_r8
-                else
-                    cld(i,k) = 0
-                end if
-#endif
+
                 ! Calculate water paths and fraction of ice
                 if (cld(i,k) > 0) then
+                  qtot = qc_rad(i,ii,jj,m) + qi_rad(i,ii,jj,m)
                   fice(i,k) = qi_rad(i,ii,jj,m)/qtot
                   cicewp(i,k) = qi_rad(i,ii,jj,m)*state%pdel(i,k)/gravit    &
                            / max(0.01_r8,cld(i,k)) ! In-cloud ice water path.


### PR DESCRIPTION
Make the behavior previously enabled by setting `-DSP_MCICA_RAD` the default for SP simulations. Essentially, this just guarantees that the cloud fraction diagnosed within the CRM is always used by the radiative transfer parameterization, rather than relying an a somewhat arbitrary condensed water amount threshold. This then enables a non-trivial subcolumn sampling of clear/cloudy "pixels" within the radiative transfer MCICA scheme. The old behavior (which we had already went away from before the Early Science campaign) set each radiative column to be either entirely clear or cloudy at a given level based on a threshold of condensed cloud water amount. Since our compsets had included the `-DSP_MCICA_RAD` flag, this PR should be BFB, and just clarifies the code somewhat, and makes it harder for someone to accidentally override the intended behavior.