### PR TITLE
Adding a new compset for MAML

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -177,6 +177,7 @@ _TESTS = {
             "ERS_Ld3_P96.ne4_ne4.FSP1V1-TEST.cam-crmout",
             "ERP_Ld3_P96.ne4_ne4.FSP2V1-TEST",
             "ERP_Ld3_P96.ne4_ne4.FSP2V1-ECPP-TEST",
+            "SMS_Ld3_P96.ne4_ne4.FSP1V1-MAML-TEST",
             "SMS_D_Ln5_P96.ne4_ne4.FSP1V1-TEST",
             "SMS_D_Ln5_P96.ne4_ne4.FSP2V1-TEST",
             )

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -177,7 +177,7 @@ _TESTS = {
             "ERS_Ld3_P96.ne4_ne4.FSP1V1-TEST.cam-crmout",
             "ERP_Ld3_P96.ne4_ne4.FSP2V1-TEST",
             "ERP_Ld3_P96.ne4_ne4.FSP2V1-ECPP-TEST",
-            "SMS_Ld3_P96.ne4_ne4.FSP1V1-MAML-TEST",
+            "SMS_Ld1_P96.ne4_ne4.FSP1V1-MAML-TEST",
             "SMS_D_Ln5_P96.ne4_ne4.FSP1V1-TEST",
             "SMS_D_Ln5_P96.ne4_ne4.FSP2V1-TEST",
             )

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -377,7 +377,7 @@
     <desc compset="CAM[45].*_BGC%B">CAM prognostic CO2 cycle turned on.</desc>
     <!-- Super-Parameterization -->
     <desc compset="_CAM5%SP1V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics and prescribed aerosol</desc>
-    <desc compset="_CAM5%SP1V1-MAML">Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol, MAML, dtime = 5 min for ne30 grid and disabled reduced radiation (the last two are specific changes to enable MAML).</desc>
+    <desc compset="_CAM5%SP1V1-MAML">Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol, MAML, dtime = 5 min (for ne30) and disabled reduced radiation (the last two are specific changes to enable MAML).</desc>
     <desc compset="_CAM5%SP2V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <desc compset="_CAM5%SP1V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
     <desc compset="_CAM5%SP1V1-MAML-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML </desc>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -105,6 +105,8 @@
       <value compset="_CAM5%SP2V1"           >-SPCAM_microp_scheme m2005 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
       <value compset="_CAM5%SP[12]V1_"       >-crm_nx 64 -crm_ny 1 -crm_nx_rad 16 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP[12]V1-TEST_"  >-crm_nx  8 -crm_ny 1 -crm_nx_rad  1 -crm_ny_rad 1 </value>
+      <value compset="_CAM5%SP1V1-MAML"      >-use_MAML -crm_nx 64 -crm_ny 1 -crm_nx_rad 64 -crm_ny_rad 1</value>
+      <value compset="_CAM5%SP1V1-MAML-TEST" >-crm_nx 8 -crm_nx_rad 8 </value>
       <value compset="_CAM5%SP2V1-ECPP-TEST" >-crm_nx  8 -crm_ny 1 -crm_nx_rad  1 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP2V1-ECPP"      >-use_ECPP </value>
       <!-- Fast SP compset for development -->
@@ -374,8 +376,10 @@
     <desc compset="CAM[45].*_BGC%B">CAM prognostic CO2 cycle turned on.</desc>
     <!-- Super-Parameterization -->
     <desc compset="_CAM5%SP1V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics and prescribed aerosol</desc>
+    <desc compset="_CAM5%SP1V1-MAML">Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML </desc>
     <desc compset="_CAM5%SP2V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <desc compset="_CAM5%SP1V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
+    <desc compset="_CAM5%SP1V1-MAML-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, 1-moment microphysics, and MAML</desc>
     <desc compset="_CAM5%SP2V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <!--  -->
   </description>
@@ -394,6 +398,25 @@
     <desc>User mods to apply to specific compset matches. </desc>
   </entry>
 
+  <value compset="SP1V1-MAML">
+     <entry id="NINST">
+       <type>integer</type>
+       <valid_values></valid_values>
+       <default_value>1</default_value>
+       <values match="last">
+       <value compclass="ATM">64</value>
+       <value compclass="LND">64</value>
+       <value compclass="ICE">64</value>
+       </value>
+     <entry id="NINST_LAYOUT">   
+       <value compclass="ATM">sequential</value>
+      </value>  
+    </values>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>Sets NINST_LND,ATM,ICE for MAML</desc>
+  </entry>
+  
   <help>
     =========================================
     CAM naming conventions

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -394,7 +394,7 @@
     <value compset="DOCN%AQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <value compset="DOCN%SOMAQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <!-- MAML uses this for setting NINST, NINST_LAYOUT -->
-    <value compset="SP1V1-MAML">$SRCROOT/components/cam/cime_config/usermods_dirs/maml</value>
+    <value compset="SP1V1-MAML_">$SRCROOT/components/cam/cime_config/usermods_dirs/maml</value>
     <value compset="SP1V1-MAML-TEST">$SRCROOT/components/cam/cime_config/usermods_dirs/maml-test</value>
     </values>
     <group>run_component_cam</group>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -377,10 +377,10 @@
     <desc compset="CAM[45].*_BGC%B">CAM prognostic CO2 cycle turned on.</desc>
     <!-- Super-Parameterization -->
     <desc compset="_CAM5%SP1V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics and prescribed aerosol</desc>
-    <desc compset="_CAM5%SP1V1-MAML">Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML </desc>
+    <desc compset="_CAM5%SP1V1-MAML">Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol, MAML, dtime = 5 min for ne30 grid and disabled reduced radiation (the last two are specific changes to enable MAML).</desc>
     <desc compset="_CAM5%SP2V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <desc compset="_CAM5%SP1V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
-    <desc compset="_CAM5%SP1V1-MAML-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML</desc>
+    <desc compset="_CAM5%SP1V1-MAML-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML </desc>
     <desc compset="_CAM5%SP2V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <!--  -->
   </description>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -105,7 +105,7 @@
       <value compset="_CAM5%SP2V1"           >-SPCAM_microp_scheme m2005 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
       <value compset="_CAM5%SP[12]V1_"       >-crm_nx 64 -crm_ny 1 -crm_nx_rad 16 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP[12]V1-TEST_"  >-crm_nx  8 -crm_ny 1 -crm_nx_rad  1 -crm_ny_rad 1 </value>
-      <value compset="_CAM5%SP1V1-MAML"      >-use_MAML -crm_nx 64 -crm_ny 1 -crm_nx_rad 64 -crm_ny_rad 1</value>
+      <value compset="_CAM5%SP1V1-MAML"      >-use_MAML -crm_nx 64 -crm_ny 1 -crm_nx_rad 64 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP1V1-MAML-TEST" >-crm_nx 8 -crm_nx_rad 8 </value>
       <value compset="_CAM5%SP2V1-ECPP-TEST" >-crm_nx  8 -crm_ny 1 -crm_nx_rad  1 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP2V1-ECPP"      >-use_ECPP </value>
@@ -384,39 +384,23 @@
     <!--  -->
   </description>
 
-  <!-- Aqua planet uses this for setting orbital parameters -->
   <entry id="CAM_USER_MODS">
     <type>char</type>
     <valid_values></valid_values>
     <default_value></default_value>
     <values match="last">
+    <!-- Aqua planet uses this for setting orbital parameters -->
     <value compset="DOCN%AQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <value compset="DOCN%SOMAQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
+    <!-- MAML uses this for setting NINST, NINST_LAYOUT -->
+    <value compset="SP1V1-MAML">$SRCROOT/components/cam/cime_config/usermods_dirs/maml</value>
+    <value compset="SP1V1-MAML-TEST">$SRCROOT/components/cam/cime_config/usermods_dirs/maml-test</value>
     </values>
     <group>run_component_cam</group>
     <file>env_case.xml</file>
     <desc>User mods to apply to specific compset matches. </desc>
   </entry>
 
-  <value compset="SP1V1-MAML">
-     <entry id="NINST">
-       <type>integer</type>
-       <valid_values></valid_values>
-       <default_value>1</default_value>
-       <values match="last">
-       <value compclass="ATM">64</value>
-       <value compclass="LND">64</value>
-       <value compclass="ICE">64</value>
-       </value>
-     <entry id="NINST_LAYOUT">   
-       <value compclass="ATM">sequential</value>
-      </value>  
-    </values>
-    <group>mach_pes</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Sets NINST_LND,ATM,ICE for MAML</desc>
-  </entry>
-  
   <help>
     =========================================
     CAM naming conventions

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -105,7 +105,8 @@
       <value compset="_CAM5%SP2V1"           >-SPCAM_microp_scheme m2005 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
       <value compset="_CAM5%SP[12]V1_"       >-crm_nx 64 -crm_ny 1 -crm_nx_rad 16 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP[12]V1-TEST_"  >-crm_nx  8 -crm_ny 1 -crm_nx_rad  1 -crm_ny_rad 1 </value>
-      <value compset="_CAM5%SP1V1-MAML"      >-use_MAML -crm_nx 64 -crm_ny 1 -crm_nx_rad 64 -crm_ny_rad 1 </value>
+      <value compset="_CAM5%SP1V1-MAML"      >-use_MAML -crm_ny 1 -crm_ny_rad 1 </value>
+      <value compset="_CAM5%SP1V1-MAML_"     >-crm_nx 64 -crm_nx_rad 64 </value>
       <value compset="_CAM5%SP1V1-MAML-TEST" >-crm_nx 8 -crm_nx_rad 8 </value>
       <value compset="_CAM5%SP2V1-ECPP-TEST" >-crm_nx  8 -crm_ny 1 -crm_nx_rad  1 -crm_ny_rad 1 </value>
       <value compset="_CAM5%SP2V1-ECPP"      >-use_ECPP </value>
@@ -379,7 +380,7 @@
     <desc compset="_CAM5%SP1V1-MAML">Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML </desc>
     <desc compset="_CAM5%SP2V1_"    >Super-parameterized E3SM with 64x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <desc compset="_CAM5%SP1V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 1-moment microphysics</desc>
-    <desc compset="_CAM5%SP1V1-MAML-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, 1-moment microphysics, and MAML</desc>
+    <desc compset="_CAM5%SP1V1-MAML-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, 1-moment microphysics, prescribed aerosol and MAML</desc>
     <desc compset="_CAM5%SP2V1-TEST">Super-parameterized E3SM with  8x1km CRM, RRTMG radiation, and 2-moment microphysics</desc>
     <!--  -->
   </description>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -371,17 +371,27 @@
     <alias>FSP1V1</alias>
     <lname>2000_CAM5%SP1V1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
+  
+  <compset>
+    <alias>FSP1V1-MAML</alias>
+    <lname>2000_CAM5%SP1V1-MAML_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
 
   <compset>
     <alias>FSP2V1</alias>
     <lname>2000_CAM5%SP2V1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
-
+  
   <!-- F testing compsets w/ reduced CRM dimensions -->
 
   <compset>
     <alias>FSP1V1-TEST</alias>
     <lname>2000_CAM5%SP1V1-TEST_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+  
+  <compset>
+    <alias>FSP1V1-MAML-TEST</alias>
+    <lname>2000_CAM5%SP1V1-MAML-TEST_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/components/cam/cime_config/usermods_dirs/maml-test/shell_commands
+++ b/components/cam/cime_config/usermods_dirs/maml-test/shell_commands
@@ -2,3 +2,4 @@
 ./xmlchange  -id NINST_ICE   -val 8
 ./xmlchange  -id NINST_LND   -val 8
 ./xmlchange  -id NINST_LAYOUT_ATM -val sequential
+./xmlchange  -id ATM_NCPL    -val 144

--- a/components/cam/cime_config/usermods_dirs/maml-test/shell_commands
+++ b/components/cam/cime_config/usermods_dirs/maml-test/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange  -id NINST_ATM   -val 8 
+./xmlchange  -id NINST_ICE   -val 8
+./xmlchange  -id NINST_LND   -val 8
+./xmlchange  -id NINST_LAYOUT_ATM -val sequential

--- a/components/cam/cime_config/usermods_dirs/maml/shell_commands
+++ b/components/cam/cime_config/usermods_dirs/maml/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange  -id NINST_ATM   -val 64
+./xmlchange  -id NINST_ICE   -val 64
+./xmlchange  -id NINST_LND   -val 64
+./xmlchange  -id NINST_LAYOUT_ATM -val sequential

--- a/components/cam/cime_config/usermods_dirs/maml/shell_commands
+++ b/components/cam/cime_config/usermods_dirs/maml/shell_commands
@@ -2,3 +2,4 @@
 ./xmlchange  -id NINST_ICE   -val 64
 ./xmlchange  -id NINST_LND   -val 64
 ./xmlchange  -id NINST_LAYOUT_ATM -val sequential
+./xmlchange  -id ATM_NCPL    -val 144

--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -786,14 +786,7 @@
 	<value grid="a%1x1_urbanc_alpha" >22772</value>
       </values>
     </entry>
-    
-    <entry id="NINST_LND">
-      <values>
-	<value compset="-MAML_CLM45"	    >64</value>
-	<value compset="-MAML-TEST_CLM45" >8</value>
-      </values>
-    </entry>
-
+  
   </entries>
 
 </compsets>

--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -786,6 +786,13 @@
 	<value grid="a%1x1_urbanc_alpha" >22772</value>
       </values>
     </entry>
+    
+    <entry id="NINST_LND">
+      <values>
+	<value compset="-MAML_CLM45"	    >64</value>
+	<value compset="-MAML-TEST_CLM45" >8</value>
+      </values>
+    </entry>
 
   </entries>
 


### PR DESCRIPTION
2 compsets are added 1) to run MAML (compset name: SP1V1-MAML), 2) to run MMF tests with MAML (compset name: SP1V1-MAML-TEST). Standalone test is not done yet, will do it tomorrow once cori is back. 