### PR TITLE
Fix 1mom optics for RRTMG

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -1618,10 +1618,20 @@ if ($nl->get_value('strat_aero_feedback') =~ /$TRUE/io) {
 
 add_default($nl, 'rad_climate', 'val'=>$radval);
 
-# Cloud optics
+# Cloud optics; for SPCAM be specific about which optics package to use
 if ($rad_pkg eq 'rrtmg' or $rad_pkg eq 'rrtmgp') {
-    add_default($nl, 'liqcldoptics');
-    add_default($nl, 'icecldoptics');
+    if ($cfg->get('use_SPCAM')) {
+        if ($cfg->get('SPCAM_microp_scheme') eq 'sam1mom') {
+            add_default($nl, 'liqcldoptics', 'val' => 'slingo');
+            add_default($nl, 'icecldoptics', 'val' => 'ebertcurry');
+        } else {
+            add_default($nl, 'liqcldoptics', 'val' => 'gammadist');
+            add_default($nl, 'icecldoptics', 'val' => 'mitchell');
+        }
+    } else {
+        add_default($nl, 'liqcldoptics');
+        add_default($nl, 'icecldoptics');
+    }
     add_default($nl, 'liqopticsfile');
     add_default($nl, 'iceopticsfile');
 }

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -4204,12 +4204,6 @@ with modal chemistry.
 Default: none
 </entry>
 
-<entry id="oldcldoptics" type="logical"  category="radiation"
-       group="rad_cnst_nl" valid_values="" >
-filepath and name for ice optics data for rrtmg
-Default: none
-</entry>
-
 <entry id="liqcldoptics" type="char*32"  category="radiation"
        group="rad_cnst_nl" valid_values="slingo,gammadist" >
 filepath and name for ice optics data for rrtmg

--- a/components/cam/src/physics/cam/crm_physics.F90
+++ b/components/cam/src/physics/cam/crm_physics.F90
@@ -299,7 +299,6 @@ subroutine crm_physics_init(species_class)
                                                'cloud scale droplet size distribution shape parameter for radiation')
     call addfld ('CRM_LAMBDA',(/'crm_nx','crm_ny','crm_nz'/), 'A', 'micrometers',  &
                                                'cloud scale slope of droplet distribution for radiation')
-    call addfld ('CRM_TAU  ', (/'crm_nx','crm_ny','crm_nz'/), 'A', '1',           'cloud scale cloud optical depth'  )
     call addfld ('CRM_WVAR' , (/'crm_nx','crm_ny','crm_nz'/), 'A', 'm/s',         'vertical velocity variance from CRM')
   endif
 

--- a/components/cam/src/physics/cam/rad_constituents.F90
+++ b/components/cam/src/physics/cam/rad_constituents.F90
@@ -54,7 +54,6 @@ integer, parameter :: cs1 = 256
 integer, public, parameter :: N_DIAG = 10
 character(len=cs1), public :: iceopticsfile, liqopticsfile
 character(len=32),  public :: icecldoptics,liqcldoptics
-logical,            public :: oldcldoptics = .false.
 
 ! Private module data
 
@@ -278,8 +277,7 @@ subroutine rad_cnst_readnl(nlfile)
                           iceopticsfile, &
                           liqopticsfile, &
                           icecldoptics,  &
-                          liqcldoptics,  &
-                          oldcldoptics
+                          liqcldoptics
 
    !-----------------------------------------------------------------------------
 
@@ -295,17 +293,6 @@ subroutine rad_cnst_readnl(nlfile)
       end if
       close(unitn)
       call freeunit(unitn)
-   end if
-
-   ! whannah - ensure that oldcldoptics=true if using SP 1-mom with RRTMG
-   call phys_getopts( use_SPCAM_out = use_SPCAM )
-   if (use_SPCAM) then
-      call phys_getopts( SPCAM_microp_scheme_out = SPCAM_microp_scheme )
-      if (SPCAM_microp_scheme .eq. 'sam1mom' .and. (.not. oldcldoptics) ) then
-         ! call endrun(routine//": oldcloudoptics must be true with SP 1-moment and RRTMG")
-         oldcldoptics = .true.
-         if (masterproc) write(iulog,*) 'rad_cnst_readnl: setting oldcldoptics = .true.'
-      end if
    end if
 
 #ifdef SPMD
@@ -326,7 +313,6 @@ subroutine rad_cnst_readnl(nlfile)
    call mpibcast (liqopticsfile, len(liqopticsfile),               mpichar, 0, mpicom)
    call mpibcast (liqcldoptics,  len(liqcldoptics),                mpichar, 0, mpicom)
    call mpibcast (icecldoptics,  len(icecldoptics),                mpichar, 0, mpicom)
-   call mpibcast (oldcldoptics,  1,                                mpilog , 0, mpicom)
 #endif
 
    ! Parse the namelist input strings

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -97,7 +97,7 @@ contains
       ncol = state%ncol
 
       ! Get ice cloud optics
-      if (trim(icecldoptics) == 'conley') then
+      if (trim(icecldoptics) == 'mitchell') then
          call get_ice_optics_sw(state, pbuf, &
                                 ice_tau, ice_tau_ssa, &
                                 ice_tau_ssa_g, ice_tau_ssa_f)
@@ -120,7 +120,7 @@ contains
       end if
       
       ! Get liquid cloud optics
-      if (trim(liqcldoptics) == 'mitchell') then
+      if (trim(liqcldoptics) == 'gammadist') then
          call get_liquid_optics_sw(state, pbuf, &
                                    liq_tau, liq_tau_ssa, &
                                    liq_tau_ssa_g, liq_tau_ssa_f)
@@ -265,7 +265,7 @@ contains
       combined_tau(:,:,:) = 0.0
 
       ! Get ice optics
-      if (trim(icecldoptics) == 'conley') then
+      if (trim(icecldoptics) == 'mitchell') then
          call get_ice_optics_lw(state, pbuf, ice_tau)
       else if (trim(icecldoptics) == 'ebertcurry') then
          call ec_ice_optics_lw(state, pbuf, ice_tau)
@@ -274,7 +274,7 @@ contains
       end if
 
       ! Get liquid optics
-      if (trim(liqcldoptics) == 'mitchell') then
+      if (trim(liqcldoptics) == 'gammadist') then
          call get_liquid_optics_lw(state, pbuf, liq_tau)
       else if (trim(liqcldoptics) == 'slingo') then
          call slingo_liq_optics_lw(state, pbuf, liq_tau)

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -42,6 +42,7 @@ contains
       use phys_control, only: phys_getopts
       use cam_abortutils, only: endrun
       use mo_optical_props, only: ty_optical_props_2str
+      use rad_constituents, only: icecldoptics, liqcldoptics
 
       ! Inputs. Right now, this uses state and pbuf, and passes these along to the
       ! individual get_*_optics routines from cloud_rad_props. This is not very
@@ -60,8 +61,6 @@ contains
       ! assumptions about array sizes.
       type(ty_optical_props_2str), intent(inout) :: optics_out
 
-      character(len=16) :: liq_optics_scheme, ice_optics_scheme
-
       ! Temporary variables to hold cloud optical properties before combining into
       ! output arrays. Same shape as output arrays, so get shapes from output.
       real(r8), dimension(nswbands,pcols,pver) :: &
@@ -76,9 +75,6 @@ contains
 
       integer :: ncol, iband, icol, ilev
 
-      ! For MMF
-      logical :: use_SPCAM
-      character(len=16) :: SPCAM_microp_scheme
 
       ! Initialize
       ice_tau = 0
@@ -100,19 +96,8 @@ contains
 
       ncol = state%ncol
 
-      ! Determine optics scheme
-      call phys_getopts(use_SPCAM_out=use_SPCAM)
-      call phys_getopts(SPCAM_microp_scheme_out=SPCAM_microp_scheme)
-      if (use_SPCAM .and. trim(SPCAM_microp_scheme) == 'sam1mom') then
-         liq_optics_scheme = 'slingo'
-         ice_optics_scheme = 'ebertcurry'
-      else
-         liq_optics_scheme = 'mitchell'
-         ice_optics_scheme = 'conley'
-      end if
-
       ! Get ice cloud optics
-      if (trim(ice_optics_scheme) == 'conley') then
+      if (trim(icecldoptics) == 'conley') then
          call get_ice_optics_sw(state, pbuf, &
                                 ice_tau, ice_tau_ssa, &
                                 ice_tau_ssa_g, ice_tau_ssa_f)
@@ -126,16 +111,16 @@ contains
                ice_tau_ssa_f(:,icol,ilev) = reordered(ice_tau_ssa_f(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
             end do
          end do
-      else if (trim(ice_optics_scheme) == 'ebertcurry') then
+      else if (trim(icecldoptics) == 'ebertcurry') then
          call ec_ice_optics_sw (state, pbuf, &
                                 ice_tau, ice_tau_ssa, &
                                 ice_tau_ssa_g, ice_tau_ssa_f)
       else
-         call endrun('Ice optics scheme ' // trim(ice_optics_scheme) // ' not recognized.')
+         call endrun('Ice optics scheme ' // trim(icecldoptics) // ' not recognized.')
       end if
       
       ! Get liquid cloud optics
-      if (trim(liq_optics_scheme) == 'mitchell') then
+      if (trim(liqcldoptics) == 'mitchell') then
          call get_liquid_optics_sw(state, pbuf, &
                                    liq_tau, liq_tau_ssa, &
                                    liq_tau_ssa_g, liq_tau_ssa_f)
@@ -149,12 +134,12 @@ contains
                liq_tau_ssa_f(:,icol,ilev) = reordered(liq_tau_ssa_f(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
             end do
          end do
-      else if (trim(liq_optics_scheme) == 'slingo') then
+      else if (trim(liqcldoptics) == 'slingo') then
          call slingo_liq_optics_sw(state, pbuf, &
                                    liq_tau, liq_tau_ssa, &
                                    liq_tau_ssa_g, liq_tau_ssa_f)
       else
-         call endrun('Liquid optics scheme ' // trim(liq_optics_scheme) // ' not recognized.')
+         call endrun('Liquid optics scheme ' // trim(liqcldoptics) // ' not recognized.')
       end if 
 
       ! Combine all cloud optics from CAM routines
@@ -251,12 +236,11 @@ contains
       use radconstants, only: nlwbands
       use cam_abortutils, only: endrun
       use mo_optical_props, only: ty_optical_props_1scl
+      use rad_constituents, only: icecldoptics, liqcldoptics
 
       type(physics_state), intent(in) :: state
       type(physics_buffer_desc), pointer :: pbuf(:)
       type(ty_optical_props_1scl), intent(inout) :: optics_out
-
-      character(len=16) :: liq_optics_scheme, ice_optics_scheme
 
       ! Cloud and snow fractions, used to weight optical properties by
       ! contributions due to cloud vs snow
@@ -269,9 +253,6 @@ contains
 
       integer :: iband, ncol
 
-      ! For MMF
-      logical :: use_SPCAM
-      character(len=16) :: SPCAM_microp_scheme
 
       ! Number of columns in this chunk
       ncol = state%ncol
@@ -283,33 +264,22 @@ contains
       cloud_tau(:,:,:) = 0.0
       combined_tau(:,:,:) = 0.0
 
-      ! Determine optics scheme
-      call phys_getopts(use_SPCAM_out=use_SPCAM)
-      call phys_getopts(SPCAM_microp_scheme_out=SPCAM_microp_scheme)
-      if (use_SPCAM .and. trim(SPCAM_microp_scheme) == 'sam1mom') then
-         liq_optics_scheme = 'slingo'
-         ice_optics_scheme = 'ebertcurry'
-      else
-         liq_optics_scheme = 'mitchell'
-         ice_optics_scheme = 'conley'
-      end if
-
       ! Get ice optics
-      if (trim(ice_optics_scheme) == 'conley') then
+      if (trim(icecldoptics) == 'conley') then
          call get_ice_optics_lw(state, pbuf, ice_tau)
-      else if (trim(ice_optics_scheme) == 'ebertcurry') then
+      else if (trim(icecldoptics) == 'ebertcurry') then
          call ec_ice_optics_lw(state, pbuf, ice_tau)
       else
-         call endrun('Ice optics scheme ' // trim(ice_optics_scheme) // ' not recognized.')
+         call endrun('Ice optics scheme ' // trim(icecldoptics) // ' not recognized.')
       end if
 
       ! Get liquid optics
-      if (trim(liq_optics_scheme) == 'mitchell') then
+      if (trim(liqcldoptics) == 'mitchell') then
          call get_liquid_optics_lw(state, pbuf, liq_tau)
-      else if (trim(liq_optics_scheme) == 'slingo') then
+      else if (trim(liqcldoptics) == 'slingo') then
          call slingo_liq_optics_lw(state, pbuf, liq_tau)
       else
-         call endrun('Ice optics scheme ' // trim(liq_optics_scheme) // ' not recognized.')
+         call endrun('Ice optics scheme ' // trim(liqcldoptics) // ' not recognized.')
       end if
 
       ! Combine liquid and ice

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -279,7 +279,7 @@ contains
       else if (trim(liqcldoptics) == 'slingo') then
          call slingo_liq_optics_lw(state, pbuf, liq_tau)
       else
-         call endrun('Ice optics scheme ' // trim(liqcldoptics) // ' not recognized.')
+         call endrun('Liquid optics scheme ' // trim(liqcldoptics) // ' not recognized.')
       end if
 
       ! Combine liquid and ice


### PR DESCRIPTION
Fix use of cloud optics for sam1mom microphysics when using RRTMG. Previously, we hard-coded the `oldcldoptics` flag when using sam1mom microphysics to try to force RRTMG to use the "old" cloud optics schemes, which do not use information from MG2 to specify particle size distribution parameters. However, this flag appears to have inconsistent behavior between the shortwave and longwave codes, and in the longwave it was just being used to add an extra diagnostic call to the old optics routines, before just being overwritten with calls to the newer optics routines anyways. Here, we fix the behavior by explicitly setting the liquid and ice optics schemes for sam1mom via edits to `build-namelist` to make sure the defaults for sam1mom are the older "Slingo" and "Ebert-Curry" optics. This will be non-BFB for tests that used sam1mom microphysics with RRTMG, but should be BFB for all RRTMGP tests, and for m2005 microphysics tests.