### PR TITLE
Fix for CRM orientation in MAML and SP_ORIENT_RAND

### DIFF
--- a/components/cam/src/control/camsrfexch.F90
+++ b/components/cam/src/control/camsrfexch.F90
@@ -594,9 +594,15 @@ subroutine cam_export(state,cam_out,pbuf)
          !zm will use large-scalel (CAM) value
          cam_out%zbot(i,j)  = state%zm(i,pver)
 
+#ifdef SP_DIR_NS
+         ! u and v swapped to account for CRM orientation in N-S direction (temporary fix)
+         cam_out%ubot(i,j) = -crm_v(i,j,1,1)
+         cam_out%vbot(i,j) =  crm_u(i,j,1,1)
+#else
          !u and v will use CRM value
          cam_out%ubot(i,j)  = crm_u(i,j,1,1)
          cam_out%vbot(i,j)  = crm_v(i,j,1,1)
+#endif
       end do
       psm1(i,lchnk)    = state%ps(i)
       srfrpdel(i,lchnk)= state%rpdel(i,pver)

--- a/components/cam/src/physics/crm/crm_input_module.F90
+++ b/components/cam/src/physics/crm/crm_input_module.F90
@@ -30,8 +30,6 @@ module crm_input_module
       real(crm_rknd), allocatable :: fluxv00(:)          ! surface momenent fluxes [N/m2]
       real(crm_rknd), allocatable :: fluxt00(:)          ! surface sensible heat fluxes [K Kg/ (m2 s)]
       real(crm_rknd), allocatable :: fluxq00(:)          ! surface latent heat fluxes [ kg/(m2 s)]
-      real(crm_rknd), allocatable :: angle(:)            ! CRM orientation angle (rad)
-
 #if defined( m2005 ) && defined( MODAL_AERO )
       real(crm_rknd), allocatable :: naermod (:,:,:)     ! Aerosol number concentration [/m3]
       real(crm_rknd), allocatable :: vaerosol(:,:,:)     ! aerosol volume concentration [m3/m3]
@@ -77,7 +75,6 @@ contains
       if (.not. allocated(this%fluxv00))  allocate(this%fluxv00(ncrms))
       if (.not. allocated(this%fluxt00))  allocate(this%fluxt00(ncrms))
       if (.not. allocated(this%fluxq00))  allocate(this%fluxq00(ncrms))
-      if (.not. allocated(this%angle))    allocate(this%angle(ncrms))
 
       call prefetch(this%zmid)
       call prefetch(this%zint)
@@ -137,7 +134,6 @@ contains
       this%fluxv00 = 0
       this%fluxt00 = 0
       this%fluxq00 = 0
-      this%angle = 0
 #if defined( m2005 ) && defined( MODAL_AERO )
       this%naermod  = 0
       this%vaerosol = 0
@@ -175,7 +171,6 @@ contains
       deallocate(this%fluxv00)
       deallocate(this%fluxt00)
       deallocate(this%fluxq00)
-      deallocate(this%angle)
 
 #if defined( m2005 ) && defined( MODAL_AERO )
       deallocate(this%naermod)

--- a/components/cam/src/physics/crm/crm_input_module.F90
+++ b/components/cam/src/physics/crm/crm_input_module.F90
@@ -30,6 +30,7 @@ module crm_input_module
       real(crm_rknd), allocatable :: fluxv00(:)          ! surface momenent fluxes [N/m2]
       real(crm_rknd), allocatable :: fluxt00(:)          ! surface sensible heat fluxes [K Kg/ (m2 s)]
       real(crm_rknd), allocatable :: fluxq00(:)          ! surface latent heat fluxes [ kg/(m2 s)]
+      real(crm_rknd), allocatable :: angle(:)            ! CRM orientation angle (rad)
 
 #if defined( m2005 ) && defined( MODAL_AERO )
       real(crm_rknd), allocatable :: naermod (:,:,:)     ! Aerosol number concentration [/m3]
@@ -76,6 +77,7 @@ contains
       if (.not. allocated(this%fluxv00))  allocate(this%fluxv00(ncrms))
       if (.not. allocated(this%fluxt00))  allocate(this%fluxt00(ncrms))
       if (.not. allocated(this%fluxq00))  allocate(this%fluxq00(ncrms))
+      if (.not. allocated(this%angle))    allocate(this%angle(ncrms))
 
       call prefetch(this%zmid)
       call prefetch(this%zint)
@@ -135,6 +137,7 @@ contains
       this%fluxv00 = 0
       this%fluxt00 = 0
       this%fluxq00 = 0
+      this%angle = 0
 #if defined( m2005 ) && defined( MODAL_AERO )
       this%naermod  = 0
       this%vaerosol = 0
@@ -172,6 +175,7 @@ contains
       deallocate(this%fluxv00)
       deallocate(this%fluxt00)
       deallocate(this%fluxq00)
+      deallocate(this%angle)
 
 #if defined( m2005 ) && defined( MODAL_AERO )
       deallocate(this%naermod)


### PR DESCRIPTION
This PR allows MAML to use CRMs that are not oriented East-West.

This PR also fixes an issue in the `SP_ORIENT_RAND` configuration wherein `crm_angle` was uninitialized prior to use and did not persist between CRM calls.

**Behavior prior to this PR:** The model would crash during the first few days when using `use_MAML` with CRMs oriented North-South (`SP_DIR_NS`). The hypothesis is that `cam_out%[uv]bot` were being populated with `crm_[uv]`, which could set up unrealistic surface forcings depending on how it's handled by the surface models (e.g., `taux` could be calculated with `v` instead of `u`).

**Solution:** Use `crm_angle` to appropriately transform `crm_[uv]` back to the GCM frame of reference. This is done by adding `crm_angle` to `pbuf` so it can both persist between CRM calls (for `SP_ORIENT_RAND`) and also be used in the `cam_export` subroutine with MAML. 

This appears to have addressed the MAML/North-South instability based on short-simulations (fingers crossed). Regardless, this fix should be incorporated because the old behavior was inconsistent.

[BFB] for ECP test suite (tested on Cori), but note these tests do not directly test this functionality.